### PR TITLE
feat: Add Collapse/Expand All actions and persistent collapsed state to tree views

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,5 +24,6 @@
     // TypeScript
     "typescript.preferences.importModuleSpecifier": "relative"
   },
-  "markdown.extension.toc.updateOnSave": false
+  "markdown.extension.toc.updateOnSave": false,
+  "cSpell.words": ["dockercompose"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "region-helper" extension will be documented in this 
 
 This changelog adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and is structured for clarity and readability, inspired by [Common Changelog](https://common-changelog.org/) and [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.4.0] - 2025-05-14
+
+- **Add Collapse/Expand All actions to Full Outline**: Buttons added to the view title bar of the Full Outline view for collapsing and expanding all items
+  - Note: "Expand All" is limited to a depth of 3 by VSCode's API
+
 ## [1.3.0] - 2025-03-18
 
 - Add PostCSS language support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ This changelog adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ## [1.4.0] - 2025-05-14
 
-- **Add Collapse/Expand All actions to Full Outline**: Buttons added to the view title bar of the Full Outline view for collapsing and expanding all items
-  - Note: "Expand All" is limited to a depth of 3 by VSCode's API
+- **Add Collapse/Expand All actions to tree views**: Action buttons added to the Regions and Full Outline tree views' title bars to collapse or expand all tree items
+  - *Bonus:* The cursor's tree item will be auto-highlighted after "Expand All" to help re-orient, regardless of the view's `shouldAutoHighlight` setting
+  - *Limitation:* The "Expand All" actions are limited to an expansion depth of 3 by VSCode's API
 
 ## [1.3.0] - 2025-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,8 @@ This changelog adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ## [1.4.0] - 2025-05-14
 
-- **Add Collapse/Expand All actions to tree views**: Action buttons added to the Regions and Full Outline tree views' title bars to collapse or expand all tree items
-  - *Bonus:* The cursor's tree item will be auto-highlighted after "Expand All" to help re-orient, regardless of the view's `shouldAutoHighlight` setting
-  - *Limitation:* The "Expand All" actions are limited to an expansion depth of 3 by VSCode's API
+- **Add Collapse/Expand All actions**: Action buttons added to the Regions and Full Outline tree views' title bars to collapse or expand all tree items
+- **Add persistent tree view state**: Expanded/collapsed items are remembered when switching files or restarting VS Code
 
 ## [1.3.0] - 2025-03-18
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "publisher": "AlyThobani",
   "name": "region-helper",
   "displayName": "Region Helper",
-  "description": "Visualize and navigate code regions in your files.",
+  "description": "Keyboard navigation, interactive tree views, fuzzy search, diagnostics, and other useful tools for code regions.",
   "repository": {
     "type": "git",
     "url": "https://github.com/alythobani/vscode-region-helper.git"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "icon": "./assets/icon.png",
   "license": "GPL-3.0-only",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "engines": {
     "vscode": "^1.94.0"
   },

--- a/package.json
+++ b/package.json
@@ -95,6 +95,16 @@
         "title": "Region Helper: Full Outline View: Start Auto-Highlighting Active Item",
         "when": "!config.regionHelper.fullOutlineView.shouldAutoHighlightActiveItem",
         "icon": "$(sync-ignored)"
+      },
+      {
+        "command": "regionHelper.fullOutlineView.collapseAll",
+        "title": "Region Helper: Full Outline View: Collapse All",
+        "icon": "$(collapse-all)"
+      },
+      {
+        "command": "regionHelper.fullOutlineView.expandAll",
+        "title": "Region Helper: Full Outline View: Expand All",
+        "icon": "$(expand-all)"
       }
     ],
     "configuration": [
@@ -450,6 +460,16 @@
         {
           "command": "regionHelper.fullOutlineView.startAutoHighlightingActiveItem",
           "when": "view == regionHelperFullTreeView && !config.regionHelper.fullOutlineView.shouldAutoHighlightActiveItem",
+          "group": "navigation"
+        },
+        {
+          "command": "regionHelper.fullOutlineView.collapseAll",
+          "when": "view == regionHelperFullTreeView",
+          "group": "navigation"
+        },
+        {
+          "command": "regionHelper.fullOutlineView.expandAll",
+          "when": "view == regionHelperFullTreeView",
           "group": "navigation"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -97,11 +97,6 @@
         "icon": "$(sync-ignored)"
       },
       {
-        "command": "regionHelper.fullOutlineView.collapseAll",
-        "title": "Region Helper: Full Outline View: Collapse All",
-        "icon": "$(collapse-all)"
-      },
-      {
         "command": "regionHelper.fullOutlineView.expandAll",
         "title": "Region Helper: Full Outline View: Expand All",
         "icon": "$(expand-all)"
@@ -463,14 +458,9 @@
           "group": "navigation"
         },
         {
-          "command": "regionHelper.fullOutlineView.collapseAll",
-          "when": "view == regionHelperFullTreeView",
-          "group": "navigation"
-        },
-        {
           "command": "regionHelper.fullOutlineView.expandAll",
           "when": "view == regionHelperFullTreeView",
-          "group": "navigation"
+          "group": "navigation@2"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -97,6 +97,11 @@
         "icon": "$(sync-ignored)"
       },
       {
+        "command": "regionHelper.regionsView.expandAll",
+        "title": "Region Helper: Regions View: Expand All",
+        "icon": "$(expand-all)"
+      },
+      {
         "command": "regionHelper.fullOutlineView.expandAll",
         "title": "Region Helper: Full Outline View: Expand All",
         "icon": "$(expand-all)"
@@ -440,22 +445,27 @@
         {
           "command": "regionHelper.regionsView.stopAutoHighlightingActiveRegion",
           "when": "view == regionHelperRegionsView && config.regionHelper.regionsView.shouldAutoHighlightActiveRegion",
-          "group": "navigation"
+          "group": "navigation@1"
         },
         {
           "command": "regionHelper.regionsView.startAutoHighlightingActiveRegion",
           "when": "view == regionHelperRegionsView && !config.regionHelper.regionsView.shouldAutoHighlightActiveRegion",
-          "group": "navigation"
+          "group": "navigation@1"
         },
         {
           "command": "regionHelper.fullOutlineView.stopAutoHighlightingActiveItem",
           "when": "view == regionHelperFullTreeView && config.regionHelper.fullOutlineView.shouldAutoHighlightActiveItem",
-          "group": "navigation"
+          "group": "navigation@1"
         },
         {
           "command": "regionHelper.fullOutlineView.startAutoHighlightingActiveItem",
           "when": "view == regionHelperFullTreeView && !config.regionHelper.fullOutlineView.shouldAutoHighlightActiveItem",
-          "group": "navigation"
+          "group": "navigation@1"
+        },
+        {
+          "command": "regionHelper.regionsView.expandAll",
+          "when": "view == regionHelperRegionsView",
+          "group": "navigation@2"
         },
         {
           "command": "regionHelper.fullOutlineView.expandAll",

--- a/src/commands/expandAndCollapseAll.ts
+++ b/src/commands/expandAndCollapseAll.ts
@@ -1,29 +1,16 @@
 import {
-  type RegionHelperClosuredCommandCallback,
-  type RegionHelperStoresCommand,
+  type RegionHelperClosuredCommand,
+  type RegionHelperClosuredParams,
 } from "./registerCommand";
 
-const expandAllFullOutlineItems: RegionHelperClosuredCommandCallback = () => {
-  // ?
-};
-
-const collapseAllFullOutlineItems: RegionHelperClosuredCommandCallback = () => {
-  // ?
-};
-
-const expandAllFullOutlineItemsCommand: RegionHelperStoresCommand = {
+const expandAllFullOutlineItemsCommand: RegionHelperClosuredCommand = {
   id: "regionHelper.fullOutlineView.expandAll",
   callback: expandAllFullOutlineItems,
-  needsStoreParams: true,
+  needsRegionHelperParams: true,
 };
 
-const collapseAllFullOutlineItemsCommand: RegionHelperStoresCommand = {
-  id: "regionHelper.fullOutlineView.collapseAll",
-  callback: collapseAllFullOutlineItems,
-  needsStoreParams: true,
-};
+export const allExpandAllCommands = [expandAllFullOutlineItemsCommand];
 
-export const allExpandAndCollapseAllCommands = [
-  expandAllFullOutlineItemsCommand,
-  collapseAllFullOutlineItemsCommand,
-];
+function expandAllFullOutlineItems({ fullTreeViewProvider }: RegionHelperClosuredParams): void {
+  fullTreeViewProvider.expandAllTreeItems();
+}

--- a/src/commands/expandAndCollapseAll.ts
+++ b/src/commands/expandAndCollapseAll.ts
@@ -1,0 +1,29 @@
+import {
+  type RegionHelperClosuredCommandCallback,
+  type RegionHelperStoresCommand,
+} from "./registerCommand";
+
+const expandAllFullOutlineItems: RegionHelperClosuredCommandCallback = () => {
+  // ?
+};
+
+const collapseAllFullOutlineItems: RegionHelperClosuredCommandCallback = () => {
+  // ?
+};
+
+const expandAllFullOutlineItemsCommand: RegionHelperStoresCommand = {
+  id: "regionHelper.fullOutlineView.expandAll",
+  callback: expandAllFullOutlineItems,
+  needsStoreParams: true,
+};
+
+const collapseAllFullOutlineItemsCommand: RegionHelperStoresCommand = {
+  id: "regionHelper.fullOutlineView.collapseAll",
+  callback: collapseAllFullOutlineItems,
+  needsStoreParams: true,
+};
+
+export const allExpandAndCollapseAllCommands = [
+  expandAllFullOutlineItemsCommand,
+  collapseAllFullOutlineItemsCommand,
+];

--- a/src/commands/expandAndCollapseAll.ts
+++ b/src/commands/expandAndCollapseAll.ts
@@ -3,14 +3,35 @@ import {
   type RegionHelperClosuredParams,
 } from "./registerCommand";
 
+// #region Exported commands
+
+const expandAllRegionTreeItemsCommand: RegionHelperClosuredCommand = {
+  id: "regionHelper.regionsView.expandAll",
+  callback: expandAllRegionTreeItems,
+  needsRegionHelperParams: true,
+};
+
 const expandAllFullOutlineItemsCommand: RegionHelperClosuredCommand = {
   id: "regionHelper.fullOutlineView.expandAll",
   callback: expandAllFullOutlineItems,
   needsRegionHelperParams: true,
 };
 
-export const allExpandAllCommands = [expandAllFullOutlineItemsCommand];
+export const allExpandAllCommands = [
+  expandAllRegionTreeItemsCommand,
+  expandAllFullOutlineItemsCommand,
+];
+
+// #endregion
+
+// #region Command implementations
+
+function expandAllRegionTreeItems({ regionTreeViewProvider }: RegionHelperClosuredParams): void {
+  regionTreeViewProvider.expandAllTreeItems();
+}
 
 function expandAllFullOutlineItems({ fullTreeViewProvider }: RegionHelperClosuredParams): void {
   fullTreeViewProvider.expandAllTreeItems();
 }
+
+// #endregion

--- a/src/commands/goToNextRegion.ts
+++ b/src/commands/goToNextRegion.ts
@@ -2,15 +2,18 @@ import * as vscode from "vscode";
 import { getNextRegion } from "../lib/getNextRegion";
 import { moveCursorToRegion } from "../lib/moveCursorToRegion";
 import { getActiveCursorLineIdx } from "../utils/getActiveCursorLineIdx";
-import { type RegionHelperStoreParams, type RegionHelperStoresCommand } from "./registerCommand";
+import {
+  type RegionHelperClosuredCommand,
+  type RegionHelperClosuredParams,
+} from "./registerCommand";
 
-export const goToNextRegionCommand: RegionHelperStoresCommand = {
+export const goToNextRegionCommand: RegionHelperClosuredCommand = {
   id: "regionHelper.goToNextRegion",
   callback: goToNextRegion,
-  needsStoreParams: true,
+  needsRegionHelperParams: true,
 };
 
-function goToNextRegion({ regionStore }: RegionHelperStoreParams): void {
+function goToNextRegion({ regionStore }: RegionHelperClosuredParams): void {
   const { flattenedRegions } = regionStore;
   const { activeTextEditor } = vscode.window;
   if (!activeTextEditor) {

--- a/src/commands/goToNextRegion.ts
+++ b/src/commands/goToNextRegion.ts
@@ -1,17 +1,17 @@
 import * as vscode from "vscode";
 import { getNextRegion } from "../lib/getNextRegion";
 import { moveCursorToRegion } from "../lib/moveCursorToRegion";
-import { type RegionStore } from "../state/RegionStore";
 import { getActiveCursorLineIdx } from "../utils/getActiveCursorLineIdx";
-import { type RegionHelperCommand } from "./registerCommand";
+import { type RegionHelperStoreParams, type RegionHelperStoresCommand } from "./registerCommand";
 
-export const goToNextRegionCommand: RegionHelperCommand = {
+export const goToNextRegionCommand: RegionHelperStoresCommand = {
   id: "regionHelper.goToNextRegion",
   callback: goToNextRegion,
-  needsRegionStore: true,
+  needsStoreParams: true,
 };
 
-function goToNextRegion({ flattenedRegions }: Pick<RegionStore, "flattenedRegions">): void {
+function goToNextRegion({ regionStore }: RegionHelperStoreParams): void {
+  const { flattenedRegions } = regionStore;
   const { activeTextEditor } = vscode.window;
   if (!activeTextEditor) {
     return;

--- a/src/commands/goToPreviousRegion.ts
+++ b/src/commands/goToPreviousRegion.ts
@@ -2,15 +2,18 @@ import * as vscode from "vscode";
 import { getPreviousRegion } from "../lib/getPreviousRegion";
 import { moveCursorToRegion } from "../lib/moveCursorToRegion";
 import { getActiveCursorLineIdx } from "../utils/getActiveCursorLineIdx";
-import { type RegionHelperStoreParams, type RegionHelperStoresCommand } from "./registerCommand";
+import {
+  type RegionHelperClosuredCommand,
+  type RegionHelperClosuredParams,
+} from "./registerCommand";
 
-export const goToPreviousRegionCommand: RegionHelperStoresCommand = {
+export const goToPreviousRegionCommand: RegionHelperClosuredCommand = {
   id: "regionHelper.goToPreviousRegion",
   callback: goToPreviousRegion,
-  needsStoreParams: true,
+  needsRegionHelperParams: true,
 };
 
-function goToPreviousRegion({ regionStore }: RegionHelperStoreParams): void {
+function goToPreviousRegion({ regionStore }: RegionHelperClosuredParams): void {
   const { flattenedRegions } = regionStore;
   const { activeTextEditor } = vscode.window;
   if (!activeTextEditor) {

--- a/src/commands/goToPreviousRegion.ts
+++ b/src/commands/goToPreviousRegion.ts
@@ -1,17 +1,17 @@
 import * as vscode from "vscode";
 import { getPreviousRegion } from "../lib/getPreviousRegion";
 import { moveCursorToRegion } from "../lib/moveCursorToRegion";
-import { type RegionStore } from "../state/RegionStore";
 import { getActiveCursorLineIdx } from "../utils/getActiveCursorLineIdx";
-import { type RegionHelperCommand } from "./registerCommand";
+import { type RegionHelperStoreParams, type RegionHelperStoresCommand } from "./registerCommand";
 
-export const goToPreviousRegionCommand: RegionHelperCommand = {
+export const goToPreviousRegionCommand: RegionHelperStoresCommand = {
   id: "regionHelper.goToPreviousRegion",
   callback: goToPreviousRegion,
-  needsRegionStore: true,
+  needsStoreParams: true,
 };
 
-function goToPreviousRegion({ flattenedRegions }: Pick<RegionStore, "flattenedRegions">): void {
+function goToPreviousRegion({ regionStore }: RegionHelperStoreParams): void {
+  const { flattenedRegions } = regionStore;
   const { activeTextEditor } = vscode.window;
   if (!activeTextEditor) {
     return;

--- a/src/commands/goToRegionBoundary.ts
+++ b/src/commands/goToRegionBoundary.ts
@@ -3,15 +3,18 @@ import { goToNextTopLevelRegionBoundary } from "../lib/goToNextTopLevelRegionBou
 import { type Region } from "../models/Region";
 import { getActiveCursorLineIdx } from "../utils/getActiveCursorLineIdx";
 import { moveCursorToFirstNonWhitespaceCharOfLine } from "../utils/moveCursorToFirstNonWhitespaceOfLine";
-import { type RegionHelperStoreParams, type RegionHelperStoresCommand } from "./registerCommand";
+import {
+  type RegionHelperClosuredCommand,
+  type RegionHelperClosuredParams,
+} from "./registerCommand";
 
-export const goToRegionBoundaryCommand: RegionHelperStoresCommand = {
+export const goToRegionBoundaryCommand: RegionHelperClosuredCommand = {
   id: "regionHelper.goToRegionBoundary",
   callback: goToRegionBoundary,
-  needsStoreParams: true,
+  needsRegionHelperParams: true,
 };
 
-function goToRegionBoundary({ regionStore }: RegionHelperStoreParams): void {
+function goToRegionBoundary({ regionStore }: RegionHelperClosuredParams): void {
   const { activeTextEditor } = vscode.window;
   if (!activeTextEditor) {
     return;

--- a/src/commands/goToRegionBoundary.ts
+++ b/src/commands/goToRegionBoundary.ts
@@ -1,18 +1,17 @@
 import * as vscode from "vscode";
 import { goToNextTopLevelRegionBoundary } from "../lib/goToNextTopLevelRegionBoundary";
 import { type Region } from "../models/Region";
-import { type RegionStore } from "../state/RegionStore";
 import { getActiveCursorLineIdx } from "../utils/getActiveCursorLineIdx";
 import { moveCursorToFirstNonWhitespaceCharOfLine } from "../utils/moveCursorToFirstNonWhitespaceOfLine";
-import { type RegionHelperCommand } from "./registerCommand";
+import { type RegionHelperStoreParams, type RegionHelperStoresCommand } from "./registerCommand";
 
-export const goToRegionBoundaryCommand: RegionHelperCommand = {
+export const goToRegionBoundaryCommand: RegionHelperStoresCommand = {
   id: "regionHelper.goToRegionBoundary",
   callback: goToRegionBoundary,
-  needsRegionStore: true,
+  needsStoreParams: true,
 };
 
-function goToRegionBoundary(regionStore: RegionStore): void {
+function goToRegionBoundary({ regionStore }: RegionHelperStoreParams): void {
   const { activeTextEditor } = vscode.window;
   if (!activeTextEditor) {
     return;

--- a/src/commands/goToRegionFromQuickPick.ts
+++ b/src/commands/goToRegionFromQuickPick.ts
@@ -2,24 +2,23 @@ import * as vscode from "vscode";
 import { getRegionDisplayName, getRegionRangeText } from "../lib/getRegionDisplayInfo";
 import { getRegionParents } from "../lib/getRegionParents";
 import { type Region } from "../models/Region";
-import { type RegionStore } from "../state/RegionStore";
 import {
   clearHighlightedRegions,
   highlightAndScrollRegionIntoView,
 } from "../utils/highlightRegion";
 import { moveCursorToFirstNonWhitespaceCharOfLine } from "../utils/moveCursorToFirstNonWhitespaceOfLine";
 import { scrollCurrentLineIntoView } from "../utils/scrollUtils";
-import { type RegionHelperCommand } from "./registerCommand";
+import { type RegionHelperStoreParams, type RegionHelperStoresCommand } from "./registerCommand";
 
 type RegionQuickPickItem = vscode.QuickPickItem & { startLineIdx: number; endLineIdx: number };
 
-export const goToRegionFromQuickPickCommand: RegionHelperCommand = {
+export const goToRegionFromQuickPickCommand: RegionHelperStoresCommand = {
   id: "regionHelper.goToRegionFromQuickPick",
   callback: goToRegionFromQuickPick,
-  needsRegionStore: true,
+  needsStoreParams: true,
 };
 
-function goToRegionFromQuickPick(regionStore: RegionStore): void {
+function goToRegionFromQuickPick({ regionStore }: RegionHelperStoreParams): void {
   const { activeTextEditor } = vscode.window;
   if (!activeTextEditor) {
     return;

--- a/src/commands/goToRegionFromQuickPick.ts
+++ b/src/commands/goToRegionFromQuickPick.ts
@@ -8,17 +8,20 @@ import {
 } from "../utils/highlightRegion";
 import { moveCursorToFirstNonWhitespaceCharOfLine } from "../utils/moveCursorToFirstNonWhitespaceOfLine";
 import { scrollCurrentLineIntoView } from "../utils/scrollUtils";
-import { type RegionHelperStoreParams, type RegionHelperStoresCommand } from "./registerCommand";
+import {
+  type RegionHelperClosuredCommand,
+  type RegionHelperClosuredParams,
+} from "./registerCommand";
 
 type RegionQuickPickItem = vscode.QuickPickItem & { startLineIdx: number; endLineIdx: number };
 
-export const goToRegionFromQuickPickCommand: RegionHelperStoresCommand = {
+export const goToRegionFromQuickPickCommand: RegionHelperClosuredCommand = {
   id: "regionHelper.goToRegionFromQuickPick",
   callback: goToRegionFromQuickPick,
-  needsStoreParams: true,
+  needsRegionHelperParams: true,
 };
 
-function goToRegionFromQuickPick({ regionStore }: RegionHelperStoreParams): void {
+function goToRegionFromQuickPick({ regionStore }: RegionHelperClosuredParams): void {
   const { activeTextEditor } = vscode.window;
   if (!activeTextEditor) {
     return;

--- a/src/commands/registerCommand.ts
+++ b/src/commands/registerCommand.ts
@@ -3,6 +3,7 @@ import { type RegionStore } from "../state/RegionStore";
 import { type FullTreeViewProvider } from "../treeView/fullTreeView/FullTreeViewProvider";
 import { goToFullTreeItemCommand } from "../treeView/fullTreeView/goToFullTreeItem";
 import { goToRegionTreeItemCommand } from "../treeView/regionTreeView/goToRegionTreeItem";
+import { type RegionTreeViewProvider } from "../treeView/regionTreeView/RegionTreeViewProvider";
 import { allExpandAllCommands } from "./expandAndCollapseAll";
 import { goToNextRegionCommand } from "./goToNextRegion";
 import { goToPreviousRegionCommand } from "./goToPreviousRegion";
@@ -18,6 +19,7 @@ type RegionHelperCommandId = `${RegionHelperExtensionId}.${string}`;
 
 export type RegionHelperClosuredParams = {
   regionStore: RegionStore;
+  regionTreeViewProvider: RegionTreeViewProvider;
   fullTreeViewProvider: FullTreeViewProvider;
 };
 

--- a/src/commands/selectCurrentRegion.ts
+++ b/src/commands/selectCurrentRegion.ts
@@ -1,15 +1,18 @@
 import * as vscode from "vscode";
 import { getActiveRegionInEditor } from "../utils/getActiveRegion";
 import { selectLines } from "../utils/selectionUtils";
-import { type RegionHelperStoreParams, type RegionHelperStoresCommand } from "./registerCommand";
+import {
+  type RegionHelperClosuredCommand,
+  type RegionHelperClosuredParams,
+} from "./registerCommand";
 
-export const selectCurrentRegionCommand: RegionHelperStoresCommand = {
+export const selectCurrentRegionCommand: RegionHelperClosuredCommand = {
   id: "regionHelper.selectCurrentRegion",
   callback: selectCurrentRegion,
-  needsStoreParams: true,
+  needsRegionHelperParams: true,
 };
 
-function selectCurrentRegion({ regionStore }: RegionHelperStoreParams): void {
+function selectCurrentRegion({ regionStore }: RegionHelperClosuredParams): void {
   const { activeTextEditor } = vscode.window;
   if (!activeTextEditor) {
     return;

--- a/src/commands/selectCurrentRegion.ts
+++ b/src/commands/selectCurrentRegion.ts
@@ -1,16 +1,15 @@
 import * as vscode from "vscode";
-import { type RegionStore } from "../state/RegionStore";
 import { getActiveRegionInEditor } from "../utils/getActiveRegion";
 import { selectLines } from "../utils/selectionUtils";
-import { type RegionHelperCommand } from "./registerCommand";
+import { type RegionHelperStoreParams, type RegionHelperStoresCommand } from "./registerCommand";
 
-export const selectCurrentRegionCommand: RegionHelperCommand = {
+export const selectCurrentRegionCommand: RegionHelperStoresCommand = {
   id: "regionHelper.selectCurrentRegion",
   callback: selectCurrentRegion,
-  needsRegionStore: true,
+  needsStoreParams: true,
 };
 
-function selectCurrentRegion(regionStore: RegionStore): void {
+function selectCurrentRegion({ regionStore }: RegionHelperStoreParams): void {
   const { activeTextEditor } = vscode.window;
   if (!activeTextEditor) {
     return;

--- a/src/commands/toggleFullOutlineViewSettings.ts
+++ b/src/commands/toggleFullOutlineViewSettings.ts
@@ -4,30 +4,30 @@ import {
   getGlobalFullOutlineViewConfigValue,
   setGlobalFullOutlineViewConfigValue,
 } from "../config/fullOutlineViewConfig";
-import { type RegionHelperCommand } from "./registerCommand";
+import { type RegionHelperNonStoresCommand } from "./registerCommand";
 
-const hideFullOutlineViewCommand: RegionHelperCommand = {
+const hideFullOutlineViewCommand: RegionHelperNonStoresCommand = {
   id: "regionHelper.fullOutlineView.hide",
   callback: hideFullOutlineView,
-  needsRegionStore: false,
+  needsStoreParams: false,
 };
 
-const showFullOutlineViewCommand: RegionHelperCommand = {
+const showFullOutlineViewCommand: RegionHelperNonStoresCommand = {
   id: "regionHelper.fullOutlineView.show",
   callback: showFullOutlineView,
-  needsRegionStore: false,
+  needsStoreParams: false,
 };
 
-const stopAutoHighlightingActiveItemCommand: RegionHelperCommand = {
+const stopAutoHighlightingActiveItemCommand: RegionHelperNonStoresCommand = {
   id: "regionHelper.fullOutlineView.stopAutoHighlightingActiveItem",
   callback: stopAutoHighlightingActiveItem,
-  needsRegionStore: false,
+  needsStoreParams: false,
 };
 
-const startAutoHighlightingActiveItemCommand: RegionHelperCommand = {
+const startAutoHighlightingActiveItemCommand: RegionHelperNonStoresCommand = {
   id: "regionHelper.fullOutlineView.startAutoHighlightingActiveItem",
   callback: startAutoHighlightingActiveItem,
-  needsRegionStore: false,
+  needsStoreParams: false,
 };
 
 export const allFullOutlineViewConfigCommands = [

--- a/src/commands/toggleFullOutlineViewSettings.ts
+++ b/src/commands/toggleFullOutlineViewSettings.ts
@@ -4,30 +4,32 @@ import {
   getGlobalFullOutlineViewConfigValue,
   setGlobalFullOutlineViewConfigValue,
 } from "../config/fullOutlineViewConfig";
-import { type RegionHelperNonStoresCommand } from "./registerCommand";
+import { type RegionHelperNonClosuredCommand } from "./registerCommand";
 
-const hideFullOutlineViewCommand: RegionHelperNonStoresCommand = {
+// #region Exported commands
+
+const hideFullOutlineViewCommand: RegionHelperNonClosuredCommand = {
   id: "regionHelper.fullOutlineView.hide",
   callback: hideFullOutlineView,
-  needsStoreParams: false,
+  needsRegionHelperParams: false,
 };
 
-const showFullOutlineViewCommand: RegionHelperNonStoresCommand = {
+const showFullOutlineViewCommand: RegionHelperNonClosuredCommand = {
   id: "regionHelper.fullOutlineView.show",
   callback: showFullOutlineView,
-  needsStoreParams: false,
+  needsRegionHelperParams: false,
 };
 
-const stopAutoHighlightingActiveItemCommand: RegionHelperNonStoresCommand = {
+const stopAutoHighlightingActiveItemCommand: RegionHelperNonClosuredCommand = {
   id: "regionHelper.fullOutlineView.stopAutoHighlightingActiveItem",
   callback: stopAutoHighlightingActiveItem,
-  needsStoreParams: false,
+  needsRegionHelperParams: false,
 };
 
-const startAutoHighlightingActiveItemCommand: RegionHelperNonStoresCommand = {
+const startAutoHighlightingActiveItemCommand: RegionHelperNonClosuredCommand = {
   id: "regionHelper.fullOutlineView.startAutoHighlightingActiveItem",
   callback: startAutoHighlightingActiveItem,
-  needsStoreParams: false,
+  needsRegionHelperParams: false,
 };
 
 export const allFullOutlineViewConfigCommands = [
@@ -36,6 +38,10 @@ export const allFullOutlineViewConfigCommands = [
   stopAutoHighlightingActiveItemCommand,
   startAutoHighlightingActiveItemCommand,
 ];
+
+// #endregion
+
+// #region Command implementations
 
 function hideFullOutlineView(): void {
   const isAlreadyVisible = getGlobalFullOutlineViewConfigValue("isVisible");
@@ -80,3 +86,5 @@ function startAutoHighlightingActiveItem(): void {
   }
   setGlobalFullOutlineViewConfigValue("shouldAutoHighlightActiveItem", true);
 }
+
+// #endregion

--- a/src/commands/toggleRegionsViewSettings.ts
+++ b/src/commands/toggleRegionsViewSettings.ts
@@ -4,33 +4,33 @@ import {
   setGlobalRegionsViewConfigValue,
   setRegionsViewVisibility,
 } from "../config/regionsViewConfig";
-import { type RegionHelperCommand } from "./registerCommand";
+import { type RegionHelperNonStoresCommand } from "./registerCommand";
 
-const hideRegionsViewCommand: RegionHelperCommand = {
+const hideRegionsViewCommand: RegionHelperNonStoresCommand = {
   id: "regionHelper.regionsView.hide",
   callback: hideRegionsView,
-  needsRegionStore: false,
+  needsStoreParams: false,
 };
 
-const showRegionsViewCommand: RegionHelperCommand = {
+const showRegionsViewCommand: RegionHelperNonStoresCommand = {
   id: "regionHelper.regionsView.show",
   callback: showRegionsView,
-  needsRegionStore: false,
+  needsStoreParams: false,
 };
 
-const stopAutoHighlightingActiveRegionCommand: RegionHelperCommand = {
+const stopAutoHighlightingActiveRegionCommand: RegionHelperNonStoresCommand = {
   id: "regionHelper.regionsView.stopAutoHighlightingActiveRegion",
   callback: stopAutoHighlightingActiveRegion,
-  needsRegionStore: false,
+  needsStoreParams: false,
 };
 
-const startAutoHighlightingActiveRegionCommand: RegionHelperCommand = {
+const startAutoHighlightingActiveRegionCommand: RegionHelperNonStoresCommand = {
   id: "regionHelper.regionsView.startAutoHighlightingActiveRegion",
   callback: startAutoHighlightingActiveRegion,
-  needsRegionStore: false,
+  needsStoreParams: false,
 };
 
-export const allRegionsViewConfigCommands: RegionHelperCommand[] = [
+export const allRegionsViewConfigCommands: RegionHelperNonStoresCommand[] = [
   hideRegionsViewCommand,
   showRegionsViewCommand,
   stopAutoHighlightingActiveRegionCommand,

--- a/src/commands/toggleRegionsViewSettings.ts
+++ b/src/commands/toggleRegionsViewSettings.ts
@@ -4,38 +4,44 @@ import {
   setGlobalRegionsViewConfigValue,
   setRegionsViewVisibility,
 } from "../config/regionsViewConfig";
-import { type RegionHelperNonStoresCommand } from "./registerCommand";
+import { type RegionHelperNonClosuredCommand } from "./registerCommand";
 
-const hideRegionsViewCommand: RegionHelperNonStoresCommand = {
+// #region Exported commands
+
+const hideRegionsViewCommand: RegionHelperNonClosuredCommand = {
   id: "regionHelper.regionsView.hide",
   callback: hideRegionsView,
-  needsStoreParams: false,
+  needsRegionHelperParams: false,
 };
 
-const showRegionsViewCommand: RegionHelperNonStoresCommand = {
+const showRegionsViewCommand: RegionHelperNonClosuredCommand = {
   id: "regionHelper.regionsView.show",
   callback: showRegionsView,
-  needsStoreParams: false,
+  needsRegionHelperParams: false,
 };
 
-const stopAutoHighlightingActiveRegionCommand: RegionHelperNonStoresCommand = {
+const stopAutoHighlightingActiveRegionCommand: RegionHelperNonClosuredCommand = {
   id: "regionHelper.regionsView.stopAutoHighlightingActiveRegion",
   callback: stopAutoHighlightingActiveRegion,
-  needsStoreParams: false,
+  needsRegionHelperParams: false,
 };
 
-const startAutoHighlightingActiveRegionCommand: RegionHelperNonStoresCommand = {
+const startAutoHighlightingActiveRegionCommand: RegionHelperNonClosuredCommand = {
   id: "regionHelper.regionsView.startAutoHighlightingActiveRegion",
   callback: startAutoHighlightingActiveRegion,
-  needsStoreParams: false,
+  needsRegionHelperParams: false,
 };
 
-export const allRegionsViewConfigCommands: RegionHelperNonStoresCommand[] = [
+export const allRegionsViewConfigCommands: RegionHelperNonClosuredCommand[] = [
   hideRegionsViewCommand,
   showRegionsViewCommand,
   stopAutoHighlightingActiveRegionCommand,
   startAutoHighlightingActiveRegionCommand,
 ];
+
+// #endregion
+
+// #region Command implementations
 
 function hideRegionsView(): void {
   const isAlreadyVisible = getGlobalRegionsViewConfigValue("isVisible");
@@ -62,3 +68,5 @@ function stopAutoHighlightingActiveRegion(): void {
 function startAutoHighlightingActiveRegion(): void {
   setGlobalRegionsViewConfigValue("shouldAutoHighlightActiveRegion", true);
 }
+
+// #endregion

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,8 +13,6 @@ import { FullTreeViewProvider } from "./treeView/fullTreeView/FullTreeViewProvid
 import { RegionTreeViewProvider } from "./treeView/regionTreeView/RegionTreeViewProvider";
 
 export function activate(context: vscode.ExtensionContext): RegionHelperAPI {
-  console.log("Activating extension 'Region Helper'");
-
   const { subscriptions } = context;
   const regionStore = RegionStore.initialize(subscriptions);
   const documentSymbolStore = DocumentSymbolStore.initialize(subscriptions);
@@ -34,6 +32,7 @@ export function activate(context: vscode.ExtensionContext): RegionHelperAPI {
   const fullTreeViewProvider = new FullTreeViewProvider(fullOutlineStore, subscriptions);
   const fullTreeView = vscode.window.createTreeView("regionHelperFullTreeView", {
     treeDataProvider: fullTreeViewProvider,
+    showCollapseAll: true,
   });
   fullTreeViewProvider.setTreeView(fullTreeView);
   subscriptions.push(fullTreeView);
@@ -41,7 +40,7 @@ export function activate(context: vscode.ExtensionContext): RegionHelperAPI {
   const regionDiagnosticsManager = new RegionDiagnosticsManager(regionStore, subscriptions);
   subscriptions.push(regionDiagnosticsManager.diagnostics);
 
-  registerAllCommands(subscriptions, { regionStore });
+  registerAllCommands(subscriptions, { regionStore, fullTreeViewProvider });
 
   return {
     // #region Region Store API

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,11 +23,12 @@ export function activate(context: vscode.ExtensionContext): RegionHelperAPI {
   );
 
   const regionTreeViewProvider = new RegionTreeViewProvider(regionStore, subscriptions);
-  const treeView = vscode.window.createTreeView("regionHelperRegionsView", {
+  const regionTreeView = vscode.window.createTreeView("regionHelperRegionsView", {
     treeDataProvider: regionTreeViewProvider,
+    showCollapseAll: true,
   });
-  regionTreeViewProvider.setTreeView(treeView);
-  subscriptions.push(treeView);
+  regionTreeViewProvider.setTreeView(regionTreeView);
+  subscriptions.push(regionTreeView);
 
   const fullTreeViewProvider = new FullTreeViewProvider(fullOutlineStore, subscriptions);
   const fullTreeView = vscode.window.createTreeView("regionHelperFullTreeView", {
@@ -40,7 +41,7 @@ export function activate(context: vscode.ExtensionContext): RegionHelperAPI {
   const regionDiagnosticsManager = new RegionDiagnosticsManager(regionStore, subscriptions);
   subscriptions.push(regionDiagnosticsManager.diagnostics);
 
-  registerAllCommands(subscriptions, { regionStore, fullTreeViewProvider });
+  registerAllCommands(subscriptions, { regionStore, regionTreeViewProvider, fullTreeViewProvider });
 
   return {
     // #region Region Store API

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,7 +41,7 @@ export function activate(context: vscode.ExtensionContext): RegionHelperAPI {
   const regionDiagnosticsManager = new RegionDiagnosticsManager(regionStore, subscriptions);
   subscriptions.push(regionDiagnosticsManager.diagnostics);
 
-  registerAllCommands(subscriptions, regionStore);
+  registerAllCommands(subscriptions, { regionStore });
 
   return {
     // #region Region Store API

--- a/src/lib/getRegionRange.ts
+++ b/src/lib/getRegionRange.ts
@@ -1,0 +1,7 @@
+import * as vscode from "vscode";
+import { type Region } from "../models/Region";
+
+export function getRegionRange(region: Region): vscode.Range {
+  const { startLineIdx, endLineIdx, endLineCharacterIdx } = region;
+  return new vscode.Range(startLineIdx, 0, endLineIdx, endLineCharacterIdx);
+}

--- a/src/lib/getVersionedDocumentId.ts
+++ b/src/lib/getVersionedDocumentId.ts
@@ -16,5 +16,13 @@ export function getCurrentActiveVersionedDocumentId(): string | undefined {
 }
 
 export function getVersionedDocumentId(document: vscode.TextDocument): string {
-  return `${document.uri.toString()}@${document.version}`;
+  return `${getDocumentId(document)}@${document.version}`;
+}
+
+export function getDocumentId(document: vscode.TextDocument): string {
+  return getDocumentIdFromUri(document.uri);
+}
+
+export function getDocumentIdFromUri(uri: vscode.Uri): string {
+  return uri.toString();
 }

--- a/src/lib/getVersionedDocumentId.ts
+++ b/src/lib/getVersionedDocumentId.ts
@@ -8,7 +8,7 @@ export function isCurrentActiveVersionedDocumentId(
 }
 
 export function getCurrentActiveVersionedDocumentId(): string | undefined {
-  const activeTextEditor = vscode.window.activeTextEditor;
+  const { activeTextEditor } = vscode.window;
   if (!activeTextEditor) {
     return undefined;
   }

--- a/src/models/Region.ts
+++ b/src/models/Region.ts
@@ -1,4 +1,7 @@
 export type Region = {
+  /** Unique ID based on the region's name (or 'unnamed') and the number of regions seen so far with
+   * that name, used for persistent collapsed/selected state. */
+  id: string;
   name?: string | undefined;
   // TODO: refactor the next 3 into just a `vscode.Range` field
   startLineIdx: number;

--- a/src/state/CollapsibleStateManager.ts
+++ b/src/state/CollapsibleStateManager.ts
@@ -67,6 +67,7 @@ export class CollapsibleStateManager {
   private onFileRename({ oldUri, newUri }: { oldUri: vscode.Uri; newUri: vscode.Uri }): void {
     const oldDocId = getDocumentIdFromUri(oldUri);
     const newDocId = getDocumentIdFromUri(newUri);
+    this.log(`onFileRename: ${oldDocId} -> ${newDocId}`);
     const store = this.collapsibleStateStoreByDocumentId[oldDocId];
     if (!store) return;
     this.collapsibleStateStoreByDocumentId[newDocId] = store;
@@ -76,6 +77,7 @@ export class CollapsibleStateManager {
 
   private onFileDelete(deletedUri: vscode.Uri): void {
     const deletedDocId = getDocumentIdFromUri(deletedUri);
+    this.log(`onFileDelete: ${deletedDocId}`);
     this.deleteDocumentStore(deletedDocId);
     this.debouncedSaveToWorkspaceState();
   }
@@ -297,7 +299,9 @@ export class CollapsibleStateManager {
 
   /** Saves the current state to VS Code's workspace storage (if storage is provided) */
   async saveToWorkspaceState(): Promise<void> {
-    this.log(`Saving to ${this.storageKey}`, this.collapsibleStateStoreByDocumentId);
+    this.log(
+      `Saving to ${this.storageKey}: ${JSON.stringify(this.collapsibleStateStoreByDocumentId)}`
+    );
     const start = performance.now();
     const serializedStoreByDocId: SerializedCollapsibleStateStoreByDocumentId = {};
     for (const [docId, store] of Object.entries(this.collapsibleStateStoreByDocumentId)) {
@@ -313,7 +317,9 @@ export class CollapsibleStateManager {
       await this.workspaceState.update(this.storageKey, undefined);
       return;
     }
-    this.log("Saving workspace stores", serializedStoreByDocId);
+    this.log(
+      `Saving serialized data to ${this.storageKey}: ${JSON.stringify(serializedStoreByDocId)}`
+    );
     await this.workspaceState.update(this.storageKey, serializedStoreByDocId);
     const end = performance.now();
     this.log(`Saved ${this.storageKey} to workspace state in ${Math.round(end - start)}ms`);

--- a/src/state/CollapsibleStateManager.ts
+++ b/src/state/CollapsibleStateManager.ts
@@ -1,0 +1,325 @@
+import * as vscode from "vscode";
+import { getDocumentIdFromUri } from "../lib/getVersionedDocumentId";
+import { debounce } from "../utils/debounce";
+import { throwNever } from "../utils/errorUtils";
+import { isEmptyObject } from "../utils/objectUtils";
+
+const CLEAN_IDS_AND_MAYBE_SWITCH_MODE_DEBOUNCE_DELAY_MS = 2000;
+const SAVE_TO_WORKSPACE_STATE_DEBOUNCE_DELAY_MS = 10000;
+
+/** Whether we should store a set of IDs for collapsed or expanded items; we can switch modes to
+ * reduce how much data we need to store. E.g. after calling "Expand All" we should switch to
+ * `collapsedItemIds` mode; after collapsing all items we should switch to `expandedItemIds`. */
+type StorageMode = "collapsedItemIds" | "expandedItemIds";
+
+/**
+ * Items are expanded by default, so the default storage mode is `collapsedItemIds` to reduce the
+ * number of IDs we need to store.
+ */
+const DEFAULT_STORAGE_MODE: StorageMode = "collapsedItemIds";
+
+type CollapsibleStateStore = {
+  /** Whether we should store collapsed or expanded item IDs */
+  storageMode: StorageMode;
+  /** A set of either collapsed or expanded item IDs, depending on `storageMode` */
+  itemIds: Set<string>;
+};
+type CollapsibleStateStoreByDocumentId = Record<string, CollapsibleStateStore>;
+
+type SerializedCollapsibleStateStore = {
+  storageMode: StorageMode;
+  itemIds: string[];
+};
+type SerializedCollapsibleStateStoreByDocumentId = Record<string, SerializedCollapsibleStateStore>;
+
+/**
+ * Manages the collapsible state (Expanded/Collapsed) of tree items across files, so that
+ * collapsible state persists across sessions and file switches.
+ */
+export class CollapsibleStateManager {
+  private log(message: string, ...args: unknown[]): void {
+    console.log(`Region Helper: CollapsibleStateManager: ${message}`, ...args);
+  }
+
+  private collapsibleStateStoreByDocumentId: CollapsibleStateStoreByDocumentId = {};
+
+  private debouncedCleanIdsAndMaybeSwitchMode = debounce(
+    this.cleanIdsAndMaybeSwitchMode.bind(this),
+    CLEAN_IDS_AND_MAYBE_SWITCH_MODE_DEBOUNCE_DELAY_MS
+  );
+
+  private debouncedSaveToWorkspaceState = debounce(async () => {
+    await this.saveToWorkspaceState();
+  }, SAVE_TO_WORKSPACE_STATE_DEBOUNCE_DELAY_MS);
+
+  constructor(private workspaceState: vscode.Memento, private storageKey: string) {
+    this.loadFromWorkspaceState();
+    vscode.workspace.onDidRenameFiles((event) => {
+      const { files } = event;
+      for (const fileRenaming of files) this.onFileRename(fileRenaming);
+    });
+    vscode.workspace.onDidDeleteFiles((event) => {
+      const { files } = event;
+      for (const deletedUri of files) this.onFileDelete(deletedUri);
+    });
+  }
+
+  private onFileRename({ oldUri, newUri }: { oldUri: vscode.Uri; newUri: vscode.Uri }): void {
+    const oldDocId = getDocumentIdFromUri(oldUri);
+    const newDocId = getDocumentIdFromUri(newUri);
+    const store = this.collapsibleStateStoreByDocumentId[oldDocId];
+    if (!store) return;
+    this.collapsibleStateStoreByDocumentId[newDocId] = store;
+    this.deleteDocumentStore(oldDocId);
+  }
+
+  private onFileDelete(deletedUri: vscode.Uri): void {
+    const deletedDocId = getDocumentIdFromUri(deletedUri);
+    this.deleteDocumentStore(deletedDocId);
+  }
+
+  /** Gets the saved collapsible state of the given item ID in the given document, if available.
+   * Assumes the item has children and thus is collapsible or expandable; if it's not, then
+   * {@link vscode.TreeItemCollapsibleState.None TreeItemCollapsibleState.None} should be used
+   * either way.
+   */
+  getSavedCollapsibleState({
+    documentId,
+    itemId,
+  }: {
+    documentId: string | undefined;
+    itemId: string;
+  }): vscode.TreeItemCollapsibleState | undefined {
+    if (documentId === undefined) {
+      console.warn("No document ID provided for collapsible state lookup");
+      return undefined;
+    }
+    const collapsibleStateStore = this.collapsibleStateStoreByDocumentId[documentId];
+    if (!collapsibleStateStore) return undefined;
+    const { storageMode, itemIds } = collapsibleStateStore;
+    switch (storageMode) {
+      case "collapsedItemIds":
+        return itemIds.has(itemId)
+          ? vscode.TreeItemCollapsibleState.Collapsed
+          : vscode.TreeItemCollapsibleState.Expanded; // defaults to Expanded, but a childless item should be None
+      case "expandedItemIds":
+        return itemIds.has(itemId)
+          ? vscode.TreeItemCollapsibleState.Expanded
+          : vscode.TreeItemCollapsibleState.Collapsed; // defaults to Collapsed, but a childless item should be None
+      default:
+        throwNever(storageMode);
+    }
+  }
+
+  // #region On collapse/expand
+
+  onCollapseTreeItem({
+    itemId,
+    documentId,
+    allParentIds,
+  }: {
+    itemId: string;
+    documentId: string | undefined;
+    allParentIds: Set<string>;
+  }): void {
+    if (documentId === undefined) {
+      console.warn("No document ID provided for collapse event");
+      return;
+    }
+    const store = this.getOrCreateStoreForDocument(documentId);
+    switch (store.storageMode) {
+      case "collapsedItemIds":
+        store.itemIds.add(itemId);
+        this.debouncedCleanIdsAndMaybeSwitchMode(store, allParentIds);
+        break;
+      case "expandedItemIds":
+        store.itemIds.delete(itemId);
+        break;
+      default:
+        throwNever(store.storageMode);
+    }
+    this.log(
+      `Collapsed item ${itemId}, ${documentId} store has ${store.itemIds.size} items now:`,
+      JSON.stringify([...store.itemIds], null, 2)
+    );
+    void this.debouncedSaveToWorkspaceState();
+  }
+
+  onExpandTreeItem({
+    itemId,
+    documentId,
+    allParentIds,
+  }: {
+    itemId: string;
+    documentId: string | undefined;
+    allParentIds: Set<string>;
+  }): void {
+    if (documentId === undefined) {
+      console.warn("No document ID provided for expand event");
+      return;
+    }
+    const store = this.getOrCreateStoreForDocument(documentId);
+    switch (store.storageMode) {
+      case "collapsedItemIds":
+        store.itemIds.delete(itemId);
+        break;
+      case "expandedItemIds":
+        store.itemIds.add(itemId);
+        this.debouncedCleanIdsAndMaybeSwitchMode(store, allParentIds);
+        break;
+      default:
+        throwNever(store.storageMode);
+    }
+    this.log(
+      `Expanded item ${itemId}, ${documentId} store now:`,
+      JSON.stringify([...store.itemIds], null, 2)
+    );
+    void this.debouncedSaveToWorkspaceState();
+  }
+
+  onExpandAllTreeItems({ documentId }: { documentId: string | undefined }): void {
+    if (documentId === undefined) {
+      this.log("No document ID provided for expand all event");
+      return;
+    }
+    const store = this.getOrCreateStoreForDocument(documentId);
+    // Regardless of the current storage mode, now that all items are going to be expanded (i.e.
+    // none collapsed), we should switch to collapsedItemIds mode and clear the item IDs set
+    store.storageMode = "collapsedItemIds";
+    store.itemIds.clear();
+    this.log(
+      `Expanded all items, ${documentId} store now:`,
+      JSON.stringify([...store.itemIds], null, 2)
+    );
+  }
+
+  // #endregion
+
+  // #region Document store management
+
+  private getOrCreateStoreForDocument(documentId: string): CollapsibleStateStore {
+    const store = this.collapsibleStateStoreByDocumentId[documentId];
+    if (store) return store;
+    const newStore: CollapsibleStateStore = {
+      storageMode: DEFAULT_STORAGE_MODE,
+      itemIds: new Set(),
+    };
+    this.collapsibleStateStoreByDocumentId[documentId] = newStore;
+    return newStore;
+  }
+
+  /** Cleans up the IDs in the store, removing any that are no longer valid (e.g. they may have been
+   * added earlier but since renamed and no longer valid in the document). Switches storage mode if
+   * the store is full after cleaning (i.e. all parent items are stored in itemIds).
+   */
+  private cleanIdsAndMaybeSwitchMode(
+    store: CollapsibleStateStore,
+    allParentIds: Set<string>
+  ): void {
+    this.removeInvalidItemIds(store, allParentIds);
+    this.maybeSwitchStorageMode(store, allParentIds);
+  }
+
+  /** Removes item IDs from the store that are not in the set of all parent IDs. This is particularly
+   * important before potentially switching storage modes depending on if all parent IDs are stored
+   * in item IDs (representing all collapsible items being expanded/collapsed), since outdated IDs
+   * would lead that check to be incorrect.
+   */
+  private removeInvalidItemIds(store: CollapsibleStateStore, allParentIds: Set<string>): void {
+    for (const itemId of store.itemIds) {
+      if (!allParentIds.has(itemId)) {
+        this.log(`Removing invalid item ID ${itemId} from store`);
+        store.itemIds.delete(itemId);
+      }
+    }
+  }
+
+  /** Switches the storage mode if all parent IDs are stored in item IDs. */
+  private maybeSwitchStorageMode(store: CollapsibleStateStore, allParentIds: Set<string>): void {
+    const { itemIds, storageMode } = store;
+    if (itemIds.size >= allParentIds.size) {
+      this.log(
+        `All ${itemIds.size} parent IDs are stored in ${storageMode}, switching storage mode`
+      );
+      itemIds.clear();
+      store.storageMode = this.getOppositeStorageMode(storageMode);
+    }
+  }
+
+  /** Returns the opposite storage mode of the given storage mode. */
+  private getOppositeStorageMode(storageMode: StorageMode): StorageMode {
+    switch (storageMode) {
+      case "collapsedItemIds":
+        return "expandedItemIds";
+      case "expandedItemIds":
+        return "collapsedItemIds";
+      default:
+        throwNever(storageMode);
+    }
+  }
+
+  private deleteDocumentStore(documentId: string): void {
+    this.log(`Deleting store for document ID ${documentId}`);
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete this.collapsibleStateStoreByDocumentId[documentId];
+  }
+
+  // #endregion
+
+  // #region Workspace storage
+
+  /** Loads persisted collapse state from storage into memory */
+  private loadFromWorkspaceState(): void {
+    const serializedStoreByDocId =
+      this.workspaceState.get<SerializedCollapsibleStateStoreByDocumentId>(this.storageKey);
+    if (!serializedStoreByDocId) {
+      console.log(
+        `Region Helper: CollapsibleStateManager: No ${this.storageKey} found in workspace state`
+      );
+      return;
+    }
+
+    console.log(
+      `Region Helper: CollapsibleStateManager: Loaded ${this.storageKey} from workspace state`,
+      serializedStoreByDocId
+    );
+
+    for (const [docId, serializedStore] of Object.entries(serializedStoreByDocId)) {
+      this.collapsibleStateStoreByDocumentId[docId] = {
+        storageMode: serializedStore.storageMode,
+        itemIds: new Set(serializedStore.itemIds),
+      };
+    }
+  }
+
+  /** Saves the current state to VS Code's workspace storage (if storage is provided) */
+  async saveToWorkspaceState(): Promise<void> {
+    this.log(`Saving to ${this.storageKey}`, this.collapsibleStateStoreByDocumentId);
+    const start = performance.now();
+    const serializedStoreByDocId: SerializedCollapsibleStateStoreByDocumentId = {};
+    for (const [docId, store] of Object.entries(this.collapsibleStateStoreByDocumentId)) {
+      const { storageMode, itemIds } = store;
+      if (this.isDefaultStore(store)) {
+        // No need to save a default store
+        continue;
+      }
+      serializedStoreByDocId[docId] = { storageMode, itemIds: Array.from(itemIds) };
+    }
+    if (isEmptyObject(serializedStoreByDocId)) {
+      this.log("All workspace stores are empty, removing storage");
+      await this.workspaceState.update(this.storageKey, undefined);
+      return;
+    }
+    this.log("Saving workspace stores", serializedStoreByDocId);
+    await this.workspaceState.update(this.storageKey, serializedStoreByDocId);
+    const end = performance.now();
+    this.log(`Saved ${this.storageKey} to workspace state in ${Math.round(end - start)}ms`);
+  }
+
+  // #endregion
+
+  private isDefaultStore(store: CollapsibleStateStore): boolean {
+    const { storageMode, itemIds } = store;
+    return storageMode === DEFAULT_STORAGE_MODE && itemIds.size === 0;
+  }
+}

--- a/src/state/CollapsibleStateManager.ts
+++ b/src/state/CollapsibleStateManager.ts
@@ -5,7 +5,7 @@ import { throwNever } from "../utils/errorUtils";
 import { isEmptyObject } from "../utils/objectUtils";
 
 const CLEAN_IDS_AND_MAYBE_SWITCH_MODE_DEBOUNCE_DELAY_MS = 2000;
-const SAVE_TO_WORKSPACE_STATE_DEBOUNCE_DELAY_MS = 10000;
+const SAVE_TO_WORKSPACE_STATE_DEBOUNCE_DELAY_MS = 15000;
 
 /** Whether we should store a set of IDs for collapsed or expanded items; we can switch modes to
  * reduce how much data we need to store. E.g. after calling "Expand All" we should switch to
@@ -71,11 +71,13 @@ export class CollapsibleStateManager {
     if (!store) return;
     this.collapsibleStateStoreByDocumentId[newDocId] = store;
     this.deleteDocumentStore(oldDocId);
+    this.debouncedSaveToWorkspaceState();
   }
 
   private onFileDelete(deletedUri: vscode.Uri): void {
     const deletedDocId = getDocumentIdFromUri(deletedUri);
     this.deleteDocumentStore(deletedDocId);
+    this.debouncedSaveToWorkspaceState();
   }
 
   /** Gets the saved collapsible state of the given item ID in the given document, if available.
@@ -142,7 +144,7 @@ export class CollapsibleStateManager {
       `Collapsed item ${itemId}, ${documentId} store has ${store.itemIds.size} items now:`,
       JSON.stringify([...store.itemIds], null, 2)
     );
-    void this.debouncedSaveToWorkspaceState();
+    this.debouncedSaveToWorkspaceState();
   }
 
   onExpandTreeItem({
@@ -174,7 +176,7 @@ export class CollapsibleStateManager {
       `Expanded item ${itemId}, ${documentId} store now:`,
       JSON.stringify([...store.itemIds], null, 2)
     );
-    void this.debouncedSaveToWorkspaceState();
+    this.debouncedSaveToWorkspaceState();
   }
 
   onExpandAllTreeItems({ documentId }: { documentId: string | undefined }): void {
@@ -191,6 +193,7 @@ export class CollapsibleStateManager {
       `Expanded all items, ${documentId} store now:`,
       JSON.stringify([...store.itemIds], null, 2)
     );
+    this.debouncedSaveToWorkspaceState();
   }
 
   // #endregion

--- a/src/state/DocumentSymbolStore.ts
+++ b/src/state/DocumentSymbolStore.ts
@@ -50,18 +50,18 @@ export class DocumentSymbolStore {
   private constructor(subscriptions: vscode.Disposable[]) {
     this.registerListeners(subscriptions);
     if (vscode.window.activeTextEditor?.document) {
-      void this.debouncedRefreshDocumentSymbols(vscode.window.activeTextEditor.document);
+      this.debouncedRefreshDocumentSymbols(vscode.window.activeTextEditor.document);
     }
   }
 
   private registerListeners(subscriptions: vscode.Disposable[]): void {
     vscode.window.onDidChangeActiveTextEditor(
-      (editor) => void this.debouncedRefreshDocumentSymbols(editor?.document),
+      (editor) => this.debouncedRefreshDocumentSymbols(editor?.document),
       undefined,
       subscriptions
     );
     vscode.workspace.onDidChangeTextDocument(
-      (event) => void this.debouncedRefreshDocumentSymbols(event.document),
+      (event) => this.debouncedRefreshDocumentSymbols(event.document),
       undefined,
       subscriptions
     );
@@ -94,7 +94,7 @@ export class DocumentSymbolStore {
               DOCUMENT_SYMBOLS_FETCH_REATTEMPT_DELAY_MS
             );
       if (documentSymbols === undefined) {
-        void this.debouncedRefreshDocumentSymbols(document, attemptIdx + 1);
+        this.debouncedRefreshDocumentSymbols(document, attemptIdx + 1);
         return;
       }
       sortSymbolsRecursivelyByStart(documentSymbols); // By default, `executeDocumentSymbolProvider` returns symbols ordered by name

--- a/src/state/FullOutlineStore.ts
+++ b/src/state/FullOutlineStore.ts
@@ -1,11 +1,11 @@
 import * as vscode from "vscode";
-import {
-  type FullTreeItem,
-  getFlattenedRegionFullTreeItem,
-  getFlattenedSymbolFullTreeItem,
-} from "../treeView/fullTreeView/FullTreeItem";
+import { type FullTreeItem } from "../treeView/fullTreeView/FullTreeItem";
 import { generateTopLevelFullTreeItems } from "../treeView/fullTreeView/generateTopLevelFullTreeItems";
 import { getActiveFullTreeItem } from "../treeView/fullTreeView/getActiveFullTreeItem";
+import {
+  getFlattenedRegionFullTreeItems,
+  getFlattenedSymbolFullTreeItems,
+} from "../treeView/fullTreeView/getFlattenedFullTreeItems";
 import { debounce } from "../utils/debounce";
 import { type DocumentSymbolStore } from "./DocumentSymbolStore";
 import { type RegionStore } from "./RegionStore";
@@ -14,6 +14,7 @@ const REFRESH_FULL_OUTLINE_DEBOUNCE_DELAY_MS = 100;
 const REFRESH_ACTIVE_ITEM_DEBOUNCE_DELAY_MS = 100;
 
 export class FullOutlineStore {
+  // #region Singleton initialization
   private static _instance: FullOutlineStore | undefined = undefined;
 
   static initialize(
@@ -34,7 +35,9 @@ export class FullOutlineStore {
     }
     return this._instance;
   }
+  // #endregion
 
+  // #region Properties
   private _topLevelItems: FullTreeItem[] = [];
   private _onDidChangeFullOutlineItems = new vscode.EventEmitter<void>();
   readonly onDidChangeFullOutlineItems = this._onDidChangeFullOutlineItems.event;
@@ -53,6 +56,8 @@ export class FullOutlineStore {
   get versionedDocumentId(): string | undefined {
     return this._versionedDocumentId;
   }
+
+  // #endregion
 
   private debouncedRefreshFullOutline = debounce(
     this.refreshFullOutline.bind(this),
@@ -108,10 +113,10 @@ export class FullOutlineStore {
 
   private refreshItems(): void {
     this.isRefreshingItems = true;
-    const { flattenedRegions } = this.regionStore;
-    const flattenedRegionItems = flattenedRegions.map(getFlattenedRegionFullTreeItem);
-    const { flattenedDocumentSymbols } = this.documentSymbolStore;
-    const flattenedSymbolItems = flattenedDocumentSymbols.map(getFlattenedSymbolFullTreeItem);
+    const flattenedRegionItems = getFlattenedRegionFullTreeItems(this.regionStore.flattenedRegions);
+    const flattenedSymbolItems = getFlattenedSymbolFullTreeItems(
+      this.documentSymbolStore.flattenedDocumentSymbols
+    );
     const topLevelItems = generateTopLevelFullTreeItems({
       flattenedRegionItems,
       flattenedSymbolItems,
@@ -156,5 +161,15 @@ export class FullOutlineStore {
       clearTimeout(this.refreshActiveItemTimeout);
       this.refreshActiveItemTimeout = undefined;
     }
+  }
+
+  onCollapseTreeItem(fullTreeItem: FullTreeItem): void {
+    const itemId = fullTreeItem.id;
+    console.log(`Collapsing item with ID: ${itemId}`);
+  }
+
+  onExpandTreeItem(fullTreeItem: FullTreeItem): void {
+    const itemId = fullTreeItem.id;
+    console.log(`Expanding item with ID: ${itemId}`);
   }
 }

--- a/src/state/FullOutlineStore.ts
+++ b/src/state/FullOutlineStore.ts
@@ -37,7 +37,7 @@ export class FullOutlineStore {
   }
   // #endregion
 
-  // #region Properties
+  // #region Public properties
   private _topLevelItems: FullTreeItem[] = [];
   private _onDidChangeFullOutlineItems = new vscode.EventEmitter<void>();
   readonly onDidChangeFullOutlineItems = this._onDidChangeFullOutlineItems.event;
@@ -91,6 +91,7 @@ export class FullOutlineStore {
     );
   }
 
+  // #region Refresh items on document change
   private onDocumentChange(event: vscode.TextDocumentChangeEvent): void {
     // RegionStore and DocumentSymbolStore will soon refresh the region and symbol data, at which
     // point we'll refresh the active item with the up-to-date data.
@@ -125,7 +126,9 @@ export class FullOutlineStore {
     this._onDidChangeFullOutlineItems.fire();
     this.isRefreshingItems = false;
   }
+  // #endregion
 
+  // #region Refresh active item on selection change
   private onSelectionChange(event: vscode.TextEditorSelectionChangeEvent): void {
     if (this.isRefreshingItems) {
       return;
@@ -162,14 +165,17 @@ export class FullOutlineStore {
       this.refreshActiveItemTimeout = undefined;
     }
   }
+  // #endregion
 
   onCollapseTreeItem(fullTreeItem: FullTreeItem): void {
     const itemId = fullTreeItem.id;
     console.log(`Collapsing item with ID: ${itemId}`);
+    // TODO: update CollapsibleStateStore
   }
 
   onExpandTreeItem(fullTreeItem: FullTreeItem): void {
     const itemId = fullTreeItem.id;
     console.log(`Expanding item with ID: ${itemId}`);
+    // TODO: update CollapsibleStateStore
   }
 }

--- a/src/test/lib/flattenRegions.test.ts
+++ b/src/test/lib/flattenRegions.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 
-import { flattenRegions } from "../../lib/flattenRegions";
+import { flattenRegionsAndCountParents } from "../../lib/flattenRegions";
 import { parseAllRegions } from "../../lib/parseAllRegions";
 import { openSampleDocument } from "../utils/openSampleDocument";
 
@@ -8,8 +8,9 @@ suite("flattenRegions", () => {
   test("Flatten regions in the sample document", async () => {
     const sampleDocument = await openSampleDocument("sampleRegionsDocument.ts");
     const { topLevelRegions } = parseAllRegions(sampleDocument);
-    const flattenedRegions = flattenRegions(topLevelRegions);
+    const { flattenedRegions, allParentIds } = flattenRegionsAndCountParents(topLevelRegions);
     assert.strictEqual(flattenedRegions.length, 9);
+    assert.strictEqual(allParentIds.size, 3);
     const regionNames = flattenedRegions.map((region) => region.name);
     assert.deepStrictEqual(regionNames, [
       "Imports",

--- a/src/treeView/fullTreeView/FullTreeItem.ts
+++ b/src/treeView/fullTreeView/FullTreeItem.ts
@@ -1,7 +1,5 @@
 import * as vscode from "vscode";
-import { getRangeText, getRegionDisplayName } from "../../lib/getRegionDisplayInfo";
-import { type Region } from "../../models/Region";
-import { getSymbolThemeIcon } from "../../utils/themeIconUtils";
+import { getRangeText } from "../../lib/getRegionDisplayInfo";
 import { makeGoToFullTreeItemCommand } from "./goToFullTreeItem";
 
 export type FullTreeItemType = "region" | "symbol";
@@ -14,6 +12,7 @@ export class FullTreeItem extends vscode.TreeItem {
   children: FullTreeItem[];
 
   constructor({
+    id,
     displayName,
     range,
     itemType,
@@ -21,6 +20,7 @@ export class FullTreeItem extends vscode.TreeItem {
     children,
     icon,
   }: {
+    id: string;
     displayName: string;
     range: vscode.Range;
     itemType: FullTreeItemType;
@@ -29,6 +29,7 @@ export class FullTreeItem extends vscode.TreeItem {
     icon: vscode.ThemeIcon | undefined;
   }) {
     super(displayName, getInitialCollapsibleState(children));
+    this.id = id;
     this.displayName = displayName;
     this.itemType = itemType;
     this.tooltip = `${displayName}: ${getRangeText(range)}`;
@@ -44,47 +45,4 @@ function getInitialCollapsibleState(children: FullTreeItem[]): vscode.TreeItemCo
   return children.length > 0
     ? vscode.TreeItemCollapsibleState.Expanded
     : vscode.TreeItemCollapsibleState.None;
-}
-
-/**
- * Turns a flattened region into a `FullTreeItem` object (no parent or children yet, since we'll
- * manually add those later when generating the full tree).
- */
-export function getFlattenedRegionFullTreeItem(region: Region): FullTreeItem {
-  return getFlattenedFullTreeItem({
-    displayName: getRegionDisplayName(region),
-    range: new vscode.Range(region.startLineIdx, 0, region.endLineIdx, region.endLineCharacterIdx),
-    itemType: "region",
-    icon: new vscode.ThemeIcon("symbol-namespace"),
-  });
-}
-
-/**
- * Turns a flattened symbol into a `FullTreeItem` object (no parent or children yet, since we'll
- * manually add those later when generating the full tree).
- */
-export function getFlattenedSymbolFullTreeItem(symbol: vscode.DocumentSymbol): FullTreeItem {
-  const maybeThemeIcon = getSymbolThemeIcon(symbol.kind);
-  return getFlattenedFullTreeItem({
-    displayName: symbol.name,
-    range: symbol.range,
-    itemType: "symbol",
-    icon: maybeThemeIcon,
-  });
-}
-
-function getFlattenedFullTreeItem({
-  itemType,
-  displayName,
-  range,
-  icon,
-}: {
-  itemType: FullTreeItemType;
-  displayName: string;
-  range: vscode.Range;
-  icon: vscode.ThemeIcon | undefined;
-}): FullTreeItem {
-  const parent = undefined;
-  const children: FullTreeItem[] = [];
-  return new FullTreeItem({ displayName, range, itemType, parent, children, icon });
 }

--- a/src/treeView/fullTreeView/FullTreeItem.ts
+++ b/src/treeView/fullTreeView/FullTreeItem.ts
@@ -5,6 +5,7 @@ import { makeGoToFullTreeItemCommand } from "./goToFullTreeItem";
 export type FullTreeItemType = "region" | "symbol";
 
 export class FullTreeItem extends vscode.TreeItem {
+  override id: string;
   displayName: string;
   itemType: FullTreeItemType;
   range: vscode.Range;

--- a/src/treeView/fullTreeView/FullTreeViewProvider.ts
+++ b/src/treeView/fullTreeView/FullTreeViewProvider.ts
@@ -86,7 +86,7 @@ export class FullTreeViewProvider implements vscode.TreeDataProvider<FullTreeIte
       return;
     }
     if (!isCurrentActiveVersionedDocumentId(this.fullOutlineStore.versionedDocumentId)) {
-      // The active item is from an old document version. We'll highlight the active item once
+      // The active item is from an old document version. We'll auto-highlight the active item once
       // FullOutlineStore fires events for the new document version.
       return;
     }
@@ -140,7 +140,10 @@ export class FullTreeViewProvider implements vscode.TreeDataProvider<FullTreeIte
         expand: 3, // Max depth
       });
     }
-    // Finish by highlighting the cursor's active item
+    // Finish by highlighting the cursor's active item. We do this regardless of the
+    // `shouldAutoHighlightActiveItem` setting, since the view is open anyway when/after calling
+    // Expand All, so there's no harm in revealing. This helps re-orient instead of scroll position
+    // being reset to the top of the tree view.
     this.highlightActiveItem();
   }
 }

--- a/src/treeView/fullTreeView/FullTreeViewProvider.ts
+++ b/src/treeView/fullTreeView/FullTreeViewProvider.ts
@@ -110,5 +110,9 @@ export class FullTreeViewProvider implements vscode.TreeDataProvider<FullTreeIte
 
   setTreeView(treeView: vscode.TreeView<FullTreeItem>): void {
     this.treeView = treeView;
+    treeView.onDidCollapseElement((event) =>
+      this.fullOutlineStore.onCollapseTreeItem(event.element)
+    );
+    treeView.onDidExpandElement((event) => this.fullOutlineStore.onExpandTreeItem(event.element));
   }
 }

--- a/src/treeView/fullTreeView/FullTreeViewProvider.ts
+++ b/src/treeView/fullTreeView/FullTreeViewProvider.ts
@@ -98,12 +98,12 @@ export class FullTreeViewProvider implements vscode.TreeDataProvider<FullTreeIte
     this.highlightActiveItem();
   }
 
-  private highlightActiveItem(): void {
+  private highlightActiveItem({ expand = false }: { expand?: boolean | number } = {}): void {
     const { activeFullOutlineItem } = this.fullOutlineStore;
     if (!this.treeView || !activeFullOutlineItem) {
       return;
     }
-    this.treeView.reveal(activeFullOutlineItem, { select: true, focus: false });
+    this.treeView.reveal(activeFullOutlineItem, { select: true, focus: false, expand });
   }
   // #endregion
 
@@ -161,6 +161,6 @@ export class FullTreeViewProvider implements vscode.TreeDataProvider<FullTreeIte
     // `shouldAutoHighlightActiveItem` setting, since the view is open anyway when/after calling
     // Expand All, so there's no harm in revealing. This helps re-orient instead of scroll position
     // being reset to the top of the tree view.
-    this.highlightActiveItem(); // TODO: call with expand: 3
+    this.highlightActiveItem({ expand: 3 });
   }
 }

--- a/src/treeView/fullTreeView/getFlattenedFullTreeItems.ts
+++ b/src/treeView/fullTreeView/getFlattenedFullTreeItems.ts
@@ -1,0 +1,105 @@
+import * as vscode from "vscode";
+import { getRegionDisplayName } from "../../lib/getRegionDisplayInfo";
+import { getRegionRange } from "../../lib/getRegionRange";
+import { type Region } from "../../models/Region";
+import { getSymbolThemeIcon, getSymbolThemeIconId } from "../../utils/themeIconUtils";
+import { FullTreeItem, type FullTreeItemType } from "./FullTreeItem";
+
+/**
+ * Creates a flattened list of region items for the Full Outline tree view, given a flattened list
+ * of regions. Turns each region into a `FullTreeItem` object, with no parent or children yet, since
+ * we'll manually add those later when generating the full tree. Gives a unique ID to each item, for
+ * the sake of persistent collapsed/selected state (see `vscode.TreeItem.id`).
+ */
+export function getFlattenedRegionFullTreeItems(flattenedRegions: Region[]): FullTreeItem[] {
+  const itemCountByPartialId = new Map<string, number>();
+  return flattenedRegions.map((region) => {
+    const displayName = getRegionDisplayName(region);
+    const itemType = "region";
+    const partialId = getPartialTreeItemId({ displayName, itemKindId: itemType });
+    const newItemCount = (itemCountByPartialId.get(partialId) ?? 0) + 1;
+    itemCountByPartialId.set(partialId, newItemCount);
+    const id = getUniqueTreeItemId({ partialId, itemCount: newItemCount });
+    return getFlattenedFullTreeItem({
+      id,
+      displayName,
+      range: getRegionRange(region),
+      itemType,
+      icon: new vscode.ThemeIcon("symbol-namespace"),
+    });
+  });
+}
+
+/**
+ * Creates a flattened list of symbol items for the Full Outline tree view, given a flattened
+ * list of document symbols. Turns each symbol into a `FullTreeItem` object, with no parent or children yet,
+ * since we'll manually add those later when generating the full tree. Gives a unique ID to each item, for
+ * the sake of persistent collapsed/selected state (see `vscode.TreeItem.id`).
+ */
+export function getFlattenedSymbolFullTreeItems(
+  flattenedDocumentSymbols: vscode.DocumentSymbol[]
+): FullTreeItem[] {
+  const itemCountByPartialId = new Map<string, number>();
+  return flattenedDocumentSymbols.map((symbol) => {
+    const displayName = symbol.name;
+    const symbolThemeIconId = getSymbolThemeIconId(symbol.kind);
+    const partialId = getPartialTreeItemId({ displayName, itemKindId: symbolThemeIconId });
+    const newItemCount = (itemCountByPartialId.get(partialId) ?? 0) + 1;
+    itemCountByPartialId.set(partialId, newItemCount);
+    const id = getUniqueTreeItemId({ partialId, itemCount: newItemCount });
+    const maybeThemeIcon = getSymbolThemeIcon(symbolThemeIconId);
+    return getFlattenedFullTreeItem({
+      id,
+      displayName: symbol.name,
+      range: symbol.range,
+      itemType: "symbol",
+      icon: maybeThemeIcon,
+    });
+  });
+}
+
+/**
+ * Generates a partial (potentially non-unique) ID for a tree item, based on its display name and an
+ * identifier for the item kind (e.g. "region" or "symbol-boolean").
+ */
+function getPartialTreeItemId({
+  displayName,
+  itemKindId,
+}: {
+  displayName: string;
+  itemKindId: string;
+}): string {
+  return `${itemKindId}-${displayName}`;
+}
+
+/**
+ * Generates a unique ID for a tree item, based on its partial ID and the number of items so far
+ * with that same partial ID. This is used to ensure unique IDs across the tree.
+ */
+function getUniqueTreeItemId({
+  partialId,
+  itemCount,
+}: {
+  partialId: string;
+  itemCount: number;
+}): string {
+  return `${partialId}-${itemCount}`;
+}
+
+function getFlattenedFullTreeItem({
+  id,
+  itemType,
+  displayName,
+  range,
+  icon,
+}: {
+  id: string;
+  itemType: FullTreeItemType;
+  displayName: string;
+  range: vscode.Range;
+  icon: vscode.ThemeIcon | undefined;
+}): FullTreeItem {
+  const parent = undefined;
+  const children: FullTreeItem[] = [];
+  return new FullTreeItem({ id, displayName, range, itemType, parent, children, icon });
+}

--- a/src/treeView/fullTreeView/getFlattenedFullTreeItems.ts
+++ b/src/treeView/fullTreeView/getFlattenedFullTreeItems.ts
@@ -9,7 +9,7 @@ import { FullTreeItem, type FullTreeItemType } from "./FullTreeItem";
  * Creates a flattened list of region items for the Full Outline tree view, given a flattened list
  * of regions. Turns each region into a `FullTreeItem` object, with no parent or children yet, since
  * we'll manually add those later when generating the full tree. Gives a unique ID to each item, for
- * the sake of persistent collapsed/selected state (see `vscode.TreeItem.id`).
+ * the sake of persistent collapsed/selected state (see {@link vscode.TreeItem.id}).
  */
 export function getFlattenedRegionFullTreeItems(flattenedRegions: Region[]): FullTreeItem[] {
   const itemCountByPartialId = new Map<string, number>();

--- a/src/treeView/fullTreeView/goToFullTreeItem.ts
+++ b/src/treeView/fullTreeView/goToFullTreeItem.ts
@@ -1,15 +1,15 @@
 import * as vscode from "vscode";
-import { type RegionHelperNonStoresCommand } from "../../commands/registerCommand";
+import { type RegionHelperNonClosuredCommand } from "../../commands/registerCommand";
 import { throwNever } from "../../utils/errorUtils";
 import { focusEditor } from "../../utils/focusEditor";
 import { moveCursorToFirstNonWhitespaceCharOfLine } from "../../utils/moveCursorToFirstNonWhitespaceOfLine";
 import { moveCursorToPosition } from "../../utils/moveCursorToPosition";
 import { type FullTreeItemType } from "./FullTreeItem";
 
-export const goToFullTreeItemCommand: RegionHelperNonStoresCommand = {
+export const goToFullTreeItemCommand: RegionHelperNonClosuredCommand = {
   id: "regionHelper.goToFullTreeItem",
   callback: goToFullTreeItem,
-  needsStoreParams: false,
+  needsRegionHelperParams: false,
 };
 
 function goToFullTreeItem(startLineIdx: number, startCharacter: number | undefined): void {

--- a/src/treeView/fullTreeView/goToFullTreeItem.ts
+++ b/src/treeView/fullTreeView/goToFullTreeItem.ts
@@ -1,15 +1,15 @@
 import * as vscode from "vscode";
-import { type RegionHelperCommand } from "../../commands/registerCommand";
+import { type RegionHelperNonStoresCommand } from "../../commands/registerCommand";
 import { throwNever } from "../../utils/errorUtils";
 import { focusEditor } from "../../utils/focusEditor";
 import { moveCursorToFirstNonWhitespaceCharOfLine } from "../../utils/moveCursorToFirstNonWhitespaceOfLine";
 import { moveCursorToPosition } from "../../utils/moveCursorToPosition";
 import { type FullTreeItemType } from "./FullTreeItem";
 
-export const goToFullTreeItemCommand: RegionHelperCommand = {
+export const goToFullTreeItemCommand: RegionHelperNonStoresCommand = {
   id: "regionHelper.goToFullTreeItem",
   callback: goToFullTreeItem,
-  needsRegionStore: false,
+  needsStoreParams: false,
 };
 
 function goToFullTreeItem(startLineIdx: number, startCharacter: number | undefined): void {

--- a/src/treeView/regionTreeView/RegionTreeItem.ts
+++ b/src/treeView/regionTreeView/RegionTreeItem.ts
@@ -4,14 +4,12 @@ import { type Region } from "../../models/Region";
 import { goToRegionTreeItemCommand } from "./goToRegionTreeItem";
 
 export class RegionTreeItem extends vscode.TreeItem {
-  constructor(public readonly region: Region) {
+  constructor(
+    public readonly region: Region,
+    initialCollapsibleState: vscode.TreeItemCollapsibleState
+  ) {
     const displayName = getRegionDisplayName(region);
-    super(
-      displayName,
-      region.children.length > 0
-        ? vscode.TreeItemCollapsibleState.Expanded
-        : vscode.TreeItemCollapsibleState.None
-    );
+    super(displayName, initialCollapsibleState);
     this.tooltip = `${displayName}: ${getRegionRangeText(region)}`;
     this.command = {
       command: goToRegionTreeItemCommand.id,

--- a/src/treeView/regionTreeView/RegionTreeViewProvider.ts
+++ b/src/treeView/regionTreeView/RegionTreeViewProvider.ts
@@ -91,12 +91,12 @@ export class RegionTreeViewProvider implements vscode.TreeDataProvider<Region> {
     this.highlightActiveRegion();
   }
 
-  private highlightActiveRegion(): void {
+  private highlightActiveRegion({ expand = false }: { expand?: boolean | number } = {}): void {
     const { activeRegion } = this.regionStore;
     if (!this.treeView || !activeRegion) {
       return;
     }
-    this.treeView.reveal(activeRegion, { select: true, focus: false });
+    this.treeView.reveal(activeRegion, { select: true, focus: false, expand });
   }
   // #endregion
 
@@ -165,6 +165,6 @@ export class RegionTreeViewProvider implements vscode.TreeDataProvider<Region> {
     // `shouldAutoHighlightActiveRegion` setting, since the view is open anyway when/after calling
     // Expand All, so there's no harm in revealing. This helps re-orient instead of scroll position
     // being reset to the top of the tree view.
-    this.highlightActiveRegion(); // TODO: call with expand: 3
+    this.highlightActiveRegion({ expand: 3 });
   }
 }

--- a/src/treeView/regionTreeView/goToRegionTreeItem.ts
+++ b/src/treeView/regionTreeView/goToRegionTreeItem.ts
@@ -1,12 +1,12 @@
 import * as vscode from "vscode";
-import { type RegionHelperCommand } from "../../commands/registerCommand";
+import { type RegionHelperNonStoresCommand } from "../../commands/registerCommand";
 import { focusEditor } from "../../utils/focusEditor";
 import { moveCursorToFirstNonWhitespaceCharOfLine } from "../../utils/moveCursorToFirstNonWhitespaceOfLine";
 
-export const goToRegionTreeItemCommand: RegionHelperCommand = {
+export const goToRegionTreeItemCommand: RegionHelperNonStoresCommand = {
   id: "regionHelper.goToRegionTreeItem",
   callback: goToRegionTreeItem,
-  needsRegionStore: false,
+  needsStoreParams: false,
 };
 
 function goToRegionTreeItem(startLineIdx: number): void {

--- a/src/treeView/regionTreeView/goToRegionTreeItem.ts
+++ b/src/treeView/regionTreeView/goToRegionTreeItem.ts
@@ -1,12 +1,12 @@
 import * as vscode from "vscode";
-import { type RegionHelperNonStoresCommand } from "../../commands/registerCommand";
+import { type RegionHelperNonClosuredCommand } from "../../commands/registerCommand";
 import { focusEditor } from "../../utils/focusEditor";
 import { moveCursorToFirstNonWhitespaceCharOfLine } from "../../utils/moveCursorToFirstNonWhitespaceOfLine";
 
-export const goToRegionTreeItemCommand: RegionHelperNonStoresCommand = {
+export const goToRegionTreeItemCommand: RegionHelperNonClosuredCommand = {
   id: "regionHelper.goToRegionTreeItem",
   callback: goToRegionTreeItem,
-  needsStoreParams: false,
+  needsRegionHelperParams: false,
 };
 
 function goToRegionTreeItem(startLineIdx: number): void {

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,8 +1,11 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function debounce<T extends (...args: any[]) => void>(func: T, delay: number): T {
+export function debounce<T extends (...args: any[]) => void>(
+  func: T,
+  delay: number
+): (...args: Parameters<T>) => void {
   let timeoutId: NodeJS.Timeout;
-  return ((...args: Parameters<T>) => {
+  return (...args: Parameters<T>) => {
     clearTimeout(timeoutId);
     timeoutId = setTimeout(() => func(...args), delay);
-  }) as T;
+  };
 }

--- a/src/utils/objectUtils.ts
+++ b/src/utils/objectUtils.ts
@@ -1,0 +1,3 @@
+export function isEmptyObject(obj: object): boolean {
+  return Object.keys(obj).length === 0;
+}

--- a/src/utils/themeIconUtils.ts
+++ b/src/utils/themeIconUtils.ts
@@ -47,8 +47,7 @@ const validSymbolThemeIconIds = new Set([
   "symbol-variable",
 ]);
 
-export function getSymbolThemeIcon(symbolKind: vscode.SymbolKind): vscode.ThemeIcon | undefined {
-  const symbolThemeIconId = getSymbolThemeIconId(symbolKind);
+export function getSymbolThemeIcon(symbolThemeIconId: string): vscode.ThemeIcon | undefined {
   if (!validSymbolThemeIconIds.has(symbolThemeIconId)) {
     // console.warn(
     //   `Couldn't find a valid theme icon for symbol kind '${vscode.SymbolKind[symbolKind]}'`
@@ -58,7 +57,11 @@ export function getSymbolThemeIcon(symbolKind: vscode.SymbolKind): vscode.ThemeI
   return new vscode.ThemeIcon(symbolThemeIconId);
 }
 
-function getSymbolThemeIconId(symbolKind: vscode.SymbolKind): string {
+/**
+ * Converts a SymbolKind enum value to a kebab-case string that can be used as a valid theme icon
+ * ID. For example, `SymbolKind.TypeParameter` becomes "symbol-type-parameter".
+ */
+export function getSymbolThemeIconId(symbolKind: vscode.SymbolKind): string {
   const pascalCaseSymbolKindName = vscode.SymbolKind[symbolKind];
   const kebabCaseSymbolKindName = toKebabCase(pascalCaseSymbolKindName);
   return `symbol-${kebabCaseSymbolKindName}`;


### PR DESCRIPTION
## Summary

Closes: #1 

This PR adds "Collapse All" and "Expand All" actions and persistent tree item collapse state to both the Full Outline and Regions tree views.

It introduces a new internal system for tracking collapsed tree items across files and sessions, while still maintaining performance even on very large files (e.g. tested on TypeScript's `checker.ts`, ~50K LOC).

## Changes

### Collapse/Expand All

- **Full Outline and Regions views**
    - Add "Expand All" action + command that calls `treeView.reveal(item, {expand: 3})` on all top level tree items
	    - We're limited by VSCode's API to 3 levels of depth per call; so some deeply nested items may stay collapsed. A tree refresh (e.g. switching back and forth between files) will fully expand all items. This should hopefully be good enough for most purposes
		- After expanding all, the cursor's active item is auto-highlighted to help re-orient
    - Add "Command All" action using VSCode's builtin `showCollapseAll: true`
		- This is our only option. While this API limitation prevents us from fully customizing the collapse logic (e.g. no command we can call, no event we can listen for), it is functional
    - Both actions are available in each view's title bar

### Persistent Collapsed State

- Add `CollapsibleStateManager` to persist and restore collapsed state per document
    - Stores either collapsed or expanded item IDs, switching between modes to minimize storage
		- By default (since items are expanded by default), and after expanding all, we track collapsed IDs
		- After collapsing all, we switch to tracking expanded IDs
	- Uses unique and stable item IDs (based on name and index)
	- Cleans up stale IDs to ensure correctness (e.g. after renames or deleted items)
	- Debounced saves to avoid performance issues on frequent expand/collapse

## Implementation Notes

- Storage efficiency:
    - Adaptive storage mode (`collapsedItemIds` or `expandedItemIds`) ensures minimal storage even on large files
    - Cleanup of outdated item IDs is essential, especially for accurately detecting "collapse all" (since there's no API event for it, we infer it based on `itemIds` set size vs total collapsible item count i.e. total parent item count)
- State is saved to workspace storage:
    - On each expand/collapse interaction (debounced)
    - On file rename/delete
    - Intentionally not on extension deactivation - avoids reliance on an unreliable lifecycle event

## Version

Bumps extension version to 1.4.0

## Screen recording


https://github.com/user-attachments/assets/a11c7e85-a7a8-4a12-bce1-a1d841303baa

