### PR TITLE
fix: Add `#region` and `#endregion` syntax support to default PHP config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 - **Add Collapse/Expand All actions**: Action buttons added to the Regions and Full Outline tree views' title bars to collapse or expand all tree items
 - **Add persistent tree view state**: Expanded/collapsed items are remembered when switching files or restarting VS Code
+- **Fix PHP default region support:** Add `#region` and `#endregion` region syntax to default PHP boundary patterns configuration
 
 ## [1.3.0] - 2025-03-18
 

--- a/package.json
+++ b/package.json
@@ -292,8 +292,14 @@
                 "endRegex": "^\\s*#\\s*endregion(?:\\s.*)?"
               },
               "php": {
-                "startRegex": "^\\s*\\/\\/\\s*#region(?:\\s+(.*?)\\s*)?$",
-                "endRegex": "^\\s*\\/\\/\\s*#endregion(?:\\s.*)?$"
+                "startRegex": [
+                  "^\\s*\\/\\/\\s*#region(?:\\s+(.*?)\\s*)?$",
+                  "^\\s*#\\s*region(?:\\s+(.*?)\\s*)?$"
+                ],
+                "endRegex": [
+                  "^\\s*\\/\\/\\s*#endregion(?:\\s.*)?$",
+                  "^\\s*#\\s*endregion(?:\\s.*)?"
+                ]
               },
               "postcss": {
                 "startRegex": "^\\s*\\/\\*\\s*#region(?:\\s+(.*?)\\s*)?\\*\\/",

--- a/src/test/samples/invalidSamples/invalidSample.php
+++ b/src/test/samples/invalidSamples/invalidSample.php
@@ -6,15 +6,15 @@ $x = 42;
 // #endregion Invalid end boundary
 // #region Invalid start boundary
 
-// #region Second Region
+#region Second Region
 class MyClass {
-    // #region   InnerRegion
+    #region   InnerRegion
     public function myMethod() {}
-    //#endregion    ends InnerRegion
+    #  endregion    ends InnerRegion
 
     // #region
     public function myMethod2() {}
     //      #endregion
 }
-// #endregion
+#endregion
 ?>

--- a/src/test/samples/validSamples/validSample.php
+++ b/src/test/samples/validSamples/validSample.php
@@ -3,15 +3,15 @@
 $x = 42;
 //   #endregion
 
-// #region Second Region
+#region Second Region
 class MyClass {
-    // #region   InnerRegion
+    #region   InnerRegion
     public function myMethod() {}
-    //#endregion    ends InnerRegion
+    #  endregion    ends InnerRegion
 
     // #region
     public function myMethod2() {}
     //      #endregion
 }
-// #endregion
+#endregion
 ?>


### PR DESCRIPTION
Fixes: #3 

Adds `#region` and `#endregion` region syntax to default PHP boundary patterns configuration