### PR TITLE
feat: extend block comment region syntax support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the "region-helper" extension will be documented in this 
 
 This changelog adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and is structured for clarity and readability, inspired by [Common Changelog](https://common-changelog.org/) and [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.4.1] - 2025-05-20
+
+- **Extend block comment region pattern support**
+  - Add block comment region syntax (e.g. `/* #region */`) to default region boundary patterns configuration for `javascript`, `javascriptreact`, `typescript`, `typescriptreact`, and `vue` languages.
+  - Adjust block comment region syntax for `less`, `css`, `postcss`, `scss`, and the above JS-based languages to allow for one or more opening/closing asterisks, e.g. `/** #region */` or `/*** #endregion ***/`
+
 ## [1.4.0] - 2025-05-14
 
 - **Add Collapse/Expand All actions**: Action buttons added to the Regions and Full Outline tree views' title bars to collapse or expand all tree items

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "icon": "./assets/icon.png",
   "license": "GPL-3.0-only",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "engines": {
     "vscode": "^1.94.0"
   },
@@ -170,8 +170,8 @@
                 "endRegex": "^\\s*\\/\\/\\s*#endregion(?:\\s.*)?$"
               },
               "css": {
-                "startRegex": "^\\s*\\/\\*\\s*#region(?:\\s+(.*?)\\s*)?\\*\\/",
-                "endRegex": "^\\s*\\/\\*\\s*#endregion(?:\\s.*)?\\*\\/"
+                "startRegex": "^\\s*\\/\\*+\\s*#region(?:\\s+(.*?)\\s*)?\\*+\\/",
+                "endRegex": "^\\s*\\/\\*+\\s*#endregion(?:\\s.*)?\\*+\\/"
               },
               "dart": {
                 "startRegex": "^\\s*\\/\\/\\s*#region(?:\\s+(.*?)\\s*)?$",
@@ -218,12 +218,24 @@
                 "endRegex": "^\\s*\\/\\/\\s*#endregion(?:\\s.*)?$"
               },
               "javascript": {
-                "startRegex": "^\\s*\\/\\/\\s*#region(?:\\s+(.*?)\\s*)?$",
-                "endRegex": "^\\s*\\/\\/\\s*#endregion(?:\\s.*)?$"
+                "startRegex": [
+                  "^\\s*\\/\\*+\\s*#region(?:\\s+(.*?)\\s*)?\\*+\\/",
+                  "^\\s*\\/\\/\\s*#region(?:\\s+(.*?)\\s*)?$"
+                ],
+                "endRegex": [
+                  "^\\s*\\/\\*+\\s*#endregion(?:\\s.*)?\\*+\\/",
+                  "^\\s*\\/\\/\\s*#endregion(?:\\s.*)?$"
+                ]
               },
               "javascriptreact": {
-                "startRegex": "^\\s*\\/\\/\\s*#region(?:\\s+(.*?)\\s*)?$",
-                "endRegex": "^\\s*\\/\\/\\s*#endregion(?:\\s.*)?$"
+                "startRegex": [
+                  "^\\s*\\/\\*+\\s*#region(?:\\s+(.*?)\\s*)?\\*+\\/",
+                  "^\\s*\\/\\/\\s*#region(?:\\s+(.*?)\\s*)?$"
+                ],
+                "endRegex": [
+                  "^\\s*\\/\\*+\\s*#endregion(?:\\s.*)?\\*+\\/",
+                  "^\\s*\\/\\/\\s*#endregion(?:\\s.*)?$"
+                ]
               },
               "json": {
                 "startRegex": "^\\s*\\/\\/\\s*#region(?:\\s+(.*?)\\s*)?$",
@@ -243,11 +255,11 @@
               },
               "less": {
                 "startRegex": [
-                  "^\\s*\\/\\*\\s*#region(?:\\s+(.*?)\\s*)?\\*\\/",
+                  "^\\s*\\/\\*+\\s*#region(?:\\s+(.*?)\\s*)?\\*+\\/",
                   "^\\s*\\/\\/\\s*#region(?:\\s+(.*?)\\s*)?$"
                 ],
                 "endRegex": [
-                  "^\\s*\\/\\*\\s*#endregion(?:\\s.*)?\\*\\/",
+                  "^\\s*\\/\\*+\\s*#endregion(?:\\s.*)?\\*+\\/",
                   "^\\s*\\/\\/\\s*#endregion(?:\\s.*)?$"
                 ]
               },
@@ -302,8 +314,8 @@
                 ]
               },
               "postcss": {
-                "startRegex": "^\\s*\\/\\*\\s*#region(?:\\s+(.*?)\\s*)?\\*\\/",
-                "endRegex": "^\\s*\\/\\*\\s*#endregion(?:\\s.*)?\\*\\/"
+                "startRegex": "^\\s*\\/\\*+\\s*#region(?:\\s+(.*?)\\s*)?\\*+\\/",
+                "endRegex": "^\\s*\\/\\*+\\s*#endregion(?:\\s.*)?\\*+\\/"
               },
               "python": {
                 "startRegex": "^\\s*#\\s*region(?:\\s+(.*?)\\s*)?$",
@@ -324,11 +336,11 @@
               "scss": {
                 "startRegex": [
                   "^\\s*\\/\\/\\s*#region(?:\\s+(.*?)\\s*)?$",
-                  "^\\s*\\/\\*\\s*#region(?:\\s+(.*?)\\s*)?\\*\\/"
+                  "^\\s*\\/\\*+\\s*#region(?:\\s+(.*?)\\s*)?\\*+\\/"
                 ],
                 "endRegex": [
                   "^\\s*\\/\\/\\s*#endregion(?:\\s.*)?$",
-                  "^\\s*\\/\\*\\s*#endregion(?:\\s.*)?\\*\\/"
+                  "^\\s*\\/\\*+\\s*#endregion(?:\\s.*)?\\*+\\/"
                 ]
               },
               "shellscript": {
@@ -356,19 +368,33 @@
                 "endRegex": "^\\s*#\\s*endregion(?:\\s.*)?"
               },
               "typescript": {
-                "startRegex": "^\\s*\\/\\/\\s*#region(?:\\s+(.*?)\\s*)?$",
-                "endRegex": "^\\s*\\/\\/\\s*#endregion(?:\\s.*)?$"
+                "startRegex": [
+                  "^\\s*\\/\\*+\\s*#region(?:\\s+(.*?)\\s*)?\\*+\\/",
+                  "^\\s*\\/\\/\\s*#region(?:\\s+(.*?)\\s*)?$"
+                ],
+                "endRegex": [
+                  "^\\s*\\/\\*+\\s*#endregion(?:\\s.*)?\\*+\\/",
+                  "^\\s*\\/\\/\\s*#endregion(?:\\s.*)?$"
+                ]
               },
               "typescriptreact": {
-                "startRegex": "^\\s*\\/\\/\\s*#region(?:\\s+(.*?)\\s*)?$",
-                "endRegex": "^\\s*\\/\\/\\s*#endregion(?:\\s.*)?$"
+                "startRegex": [
+                  "^\\s*\\/\\*+\\s*#region(?:\\s+(.*?)\\s*)?\\*+\\/",
+                  "^\\s*\\/\\/\\s*#region(?:\\s+(.*?)\\s*)?$"
+                ],
+                "endRegex": [
+                  "^\\s*\\/\\*+\\s*#endregion(?:\\s.*)?\\*+\\/",
+                  "^\\s*\\/\\/\\s*#endregion(?:\\s.*)?$"
+                ]
               },
               "vue": {
                 "startRegex": [
+                  "^\\s*\\/\\*+\\s*#region(?:\\s+(.*?)\\s*)?\\*+\\/",
                   "^\\s*\\/\\/\\s*#region(?:\\s+(.*?)\\s*)?$",
                   "^\\s*<!--\\s*#region(?:\\s+(.*?)\\s*)?-->"
                 ],
                 "endRegex": [
+                  "^\\s*\\/\\*+\\s*#endregion(?:\\s.*)?\\*+\\/",
                   "^\\s*\\/\\/\\s*#endregion(?:\\s.*)?$",
                   "^\\s*<!--\\s*#endregion(?:\\s.*)?-->"
                 ]

--- a/src/test/samples/validSamples/validSample.css
+++ b/src/test/samples/validSamples/validSample.css
@@ -4,14 +4,14 @@ body {
 }
 /*#endregion*/
 
-/*   #region Second Region */
+/**   #region Second Region **/
 .container {
   /*  #region    InnerRegion   */
   display: flex;
-  /*  #endregion   ends InnerRegion   */
+  /*** #endregion   ends InnerRegion   **/
 
   /* #region */
   padding: 20px;
   /* #endregion */
 }
-/* #endregion */
+/* #endregion**/

--- a/src/test/samples/validSamples/validSample.js
+++ b/src/test/samples/validSamples/validSample.js
@@ -2,15 +2,15 @@
 const x = 42;
 //#endregion
 
-// #region Second Region
+/***   #region Second Region */
 class MyClass {
   //    #region   InnerRegion
   method() {}
   //      #endregion   ends InnerRegion
 
-  // #region
+  /*#region */
   anotherMethod() {}
-  //#endregion
+  /*   #endregion **/
 }
 
-//  #endregion
+/**#endregion */

--- a/src/test/samples/validSamples/validSample.jsx
+++ b/src/test/samples/validSamples/validSample.jsx
@@ -2,7 +2,7 @@
 const x = 42;
 //#endregion
 
-// #region Second Region
+/***   #region Second Region */
 class MyComponent extends React.Component {
   //    #region    InnerRegion
   render() {
@@ -14,10 +14,11 @@ class MyComponent extends React.Component {
   }
   //   #endregion   ends InnerRegion
 
-  //  #region
+  /*#region */
   someMethodInUnnamedRegion() {
     return 42;
   }
-  //#endregion
+  /*   #endregion */
 }
-// #endregion
+
+/**#endregion */

--- a/src/test/samples/validSamples/validSample.less
+++ b/src/test/samples/validSamples/validSample.less
@@ -6,11 +6,11 @@
 .container {
   /*  #region    InnerRegion   */
   color: @main-color;
-  /*  #endregion   ends InnerRegion  */
+  /*    #endregion   ends InnerRegion  */
 
-  /* #region */
+  /***    #region */
   margin: 20px;
-  /* #endregion */
+  /**#endregion */
 }
 
 //   #endregion 

--- a/src/test/samples/validSamples/validSample.pcss
+++ b/src/test/samples/validSamples/validSample.pcss
@@ -4,14 +4,14 @@ body {
 }
 /*#endregion*/
 
-/*   #region Second Region */
+/**   #region Second Region **/
 .container {
   /*  #region    InnerRegion   */
   display: flex;
-  /*  #endregion   ends InnerRegion   */
+  /*** #endregion   ends InnerRegion   **/
 
   /* #region */
   padding: 20px;
   /* #endregion */
 }
-/* #endregion */
+/* #endregion**/

--- a/src/test/samples/validSamples/validSample.scss
+++ b/src/test/samples/validSamples/validSample.scss
@@ -2,11 +2,11 @@
 $main-color: #3498db;
 /*#endregion*/
 
-/*   #region Second Region   */
+/**   #region Second Region **/
 .container {
   /*  #region    InnerRegion   */
   color: $main-color;
-  /*  #endregion   ends InnerRegion   */
+  /*** #endregion   ends InnerRegion   **/
 
   //  #region 
   margin: 20px;

--- a/src/test/samples/validSamples/validSample.ts
+++ b/src/test/samples/validSamples/validSample.ts
@@ -2,14 +2,15 @@
 const x = 42;
 //#endregion
 
-//  #region Second Region
+/***   #region Second Region */
 class MyClass {
   //  #region        InnerRegion
   method() {}
   //    #endregion      ends InnerRegion
 
-  //    #region
+  /*#region */
   method2() {}
-  //#endregion
+  /*   #endregion */
 }
-// #endregion
+
+/**#endregion */

--- a/src/test/samples/validSamples/validSample.tsx
+++ b/src/test/samples/validSamples/validSample.tsx
@@ -2,7 +2,7 @@
 const x: number = 42;
 //#endregion
 
-// #region Second Region
+/***   #region Second Region */
 class MyComponent extends React.Component {
   //   #region    InnerRegion
   render(): JSX.Element {
@@ -14,10 +14,11 @@ class MyComponent extends React.Component {
   }
   //  #endregion   ends InnerRegion
 
-  //  #region
+  /*#region */
   render2(): JSX.Element {
     return <div>Unnamed region</div>;
   }
-  //#endregion
+  /*   #endregion */
 }
-// #endregion
+
+/**#endregion */

--- a/src/test/samples/validSamples/validSample.vue
+++ b/src/test/samples/validSamples/validSample.vue
@@ -7,19 +7,19 @@
 <!--   #region Second Region -->
 <script>
 export default {
-  //  #region    InnerRegion  
+  //#region    InnerRegion  
   data() {
     return { msg: "Hello" };
   },
-  //  #endregion   ends InnerRegion  
+  //   #endregion   ends InnerRegion  
 
-  // #region
+  /***   #region */
   methods: {
     sayHello() {
       console.log("Hello");
     }
   }
-  // #endregion
+  /*#endregion */
 };
 </script>
 <!-- #endregion -->


### PR DESCRIPTION
Closes #6 

- add block comment region pattern syntax to js/jsx/ts/tsx/vue default configs
- allow block comments to have one or more asterisks at start/end