### PR TITLE
fix: focus editor using `focusActiveEditorGroup` instead of `showTextDocument`

### DIFF
--- a/src/treeView/fullTreeView/goToFullTreeItem.ts
+++ b/src/treeView/fullTreeView/goToFullTreeItem.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { type RegionHelperNonClosuredCommand } from "../../commands/registerCommand";
 import { throwNever } from "../../utils/errorUtils";
-import { focusEditor } from "../../utils/focusEditor";
+import { focusActiveEditorGroup } from "../../utils/focusEditor";
 import { moveCursorToFirstNonWhitespaceCharOfLine } from "../../utils/moveCursorToFirstNonWhitespaceOfLine";
 import { moveCursorToPosition } from "../../utils/moveCursorToPosition";
 import { type FullTreeItemType } from "./FullTreeItem";
@@ -31,7 +31,7 @@ function goToFullTreeItem(startLineIdx: number, startCharacter: number | undefin
       revealType: vscode.TextEditorRevealType.InCenterIfOutsideViewport,
     });
   }
-  focusEditor(activeTextEditor);
+  void focusActiveEditorGroup();
 }
 
 export function makeGoToFullTreeItemCommand(

--- a/src/treeView/regionTreeView/goToRegionTreeItem.ts
+++ b/src/treeView/regionTreeView/goToRegionTreeItem.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { type RegionHelperNonClosuredCommand } from "../../commands/registerCommand";
-import { focusEditor } from "../../utils/focusEditor";
+import { focusActiveEditorGroup } from "../../utils/focusEditor";
 import { moveCursorToFirstNonWhitespaceCharOfLine } from "../../utils/moveCursorToFirstNonWhitespaceOfLine";
 
 export const goToRegionTreeItemCommand: RegionHelperNonClosuredCommand = {
@@ -19,5 +19,5 @@ function goToRegionTreeItem(startLineIdx: number): void {
     lineIdx: startLineIdx,
     revealType: vscode.TextEditorRevealType.InCenterIfOutsideViewport,
   });
-  focusEditor(activeTextEditor);
+  void focusActiveEditorGroup();
 }

--- a/src/utils/focusEditor.ts
+++ b/src/utils/focusEditor.ts
@@ -1,5 +1,15 @@
 import * as vscode from "vscode";
 
-export function focusEditor(activeTextEditor: vscode.TextEditor): void {
-  vscode.window.showTextDocument(activeTextEditor.document, activeTextEditor.viewColumn);
+/** Shows the given editor.
+ *
+ * Not currently used anywhere, but kept for reference. Was previously used as a way to focus the
+ * active editor after clicking a tree item to navigate to it, but this was buggy for Jupyter
+ * notebooks (would open the cell contents in a new read-only editor). */
+export function showEditor(editor: vscode.TextEditor): void {
+  vscode.window.showTextDocument(editor.document, editor.viewColumn);
+}
+
+/** Focuses the active editor group. */
+export async function focusActiveEditorGroup(): Promise<void> {
+  await vscode.commands.executeCommand("workbench.action.focusActiveEditorGroup");
 }


### PR DESCRIPTION
Fixes: #14 

- replaces the previous `focusEditor` call at the end of `goToRegionTreeItem` and `goToFullTreeItem`, with a call to `focusActiveEditorGroup` (`workbench.action.focusActiveEditorGroup`)
  - `focusEditor`'s implementation called `vscode.window.showTextDocument` which in the context of Jupyter notebooks, opened the cell contents in a new editor
- keeps the old `focusEditor` code around for reference / in case it's useful for something in the future, but renamed more precisely to `showEditor`